### PR TITLE
Provide optional position parameter for @ItemClick (& others)

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemClick.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemClick.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Target;
  * adapter, at the selected position. It may be of any type, so be careful about
  * potential ClassCastException.
  * 
+ * If the parameter is an int, it will be the position instead of the object from the adapter.
+ * 
  * The annotation value should be one of R.id.* fields. If not set, the method
  * name will be used as the R.id.* field name.
  * 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemLongClick.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemLongClick.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Target;
  * adapter, at the selected position. It may be of any type, so be careful about
  * potential ClassCastException.
  * 
+ * If the parameter is an int, it will be the position instead of the object from the adapter.
+ * 
  * The annotation value should be one of R.id.* fields. If not set, the method
  * name will be used as the R.id.* field name..
  * 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemSelect.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/ItemSelect.java
@@ -23,9 +23,11 @@ import java.lang.annotation.Target;
 /**
  * Should be used on item selected listener methods for AdapterView classes
  * 
- * The method may have 1 or 2 parameter. The first parameter must be a boolean,
+ * The method may have 1 or 2 parameters. The first parameter must be a boolean,
  * and the second is the object from the adapter, at the selected position. It
  * may be of any type, so be careful about potential ClassCastException.
+ * 
+ * If the second parameter is an int, it will be the position instead of the object from the adapter.
  * 
  * The first boolean parameter indicates if something has been selected or not.
  * If nothing was selected, the second parameter will be null.

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemClickProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemClickProcessor.java
@@ -21,6 +21,8 @@ import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 import com.googlecode.androidannotations.annotations.ItemClick;
 import com.googlecode.androidannotations.rclass.IRClass;
@@ -80,8 +82,14 @@ public class ItemClickProcessor extends MultipleResIdsBasedProcessor implements 
 
 		if (hasItemParameter) {
 			VariableElement parameter = parameters.get(0);
-			String parameterQualifiedName = parameter.asType().toString();
-			itemClickCall.arg(JExpr.cast(holder.refClass(parameterQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+			
+			TypeMirror parameterType = parameter.asType();
+			if (parameterType.getKind() == TypeKind.INT) {
+				itemClickCall.arg(onItemClickPositionParam);
+			} else {
+				String parameterTypeQualifiedName = parameterType.toString();
+				itemClickCall.arg(JExpr.cast(holder.refClass(parameterTypeQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+			}
 		}
 
 		for (JFieldRef idRef : idsRefs) {

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemLongClickProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemLongClickProcessor.java
@@ -93,8 +93,14 @@ public class ItemLongClickProcessor extends MultipleResIdsBasedProcessor impleme
 
 		if (hasItemParameter) {
 			VariableElement parameter = parameters.get(0);
-			String parameterQualifiedName = parameter.asType().toString();
-			itemClickCall.arg(JExpr.cast(holder.refClass(parameterQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+			
+			TypeMirror parameterType = parameter.asType();
+			if (parameterType.getKind() == TypeKind.INT) {
+				itemClickCall.arg(onItemClickPositionParam);
+			} else {
+				String parameterTypeQualifiedName = parameterType.toString();
+				itemClickCall.arg(JExpr.cast(holder.refClass(parameterTypeQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+			}
 		}
 
 		for (JFieldRef idRef : idsRefs) {

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemSelectedProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/ItemSelectedProcessor.java
@@ -15,12 +15,17 @@
  */
 package com.googlecode.androidannotations.processing;
 
+import static com.sun.codemodel.JExpr._null;
+import static com.sun.codemodel.JExpr.lit;
+
 import java.lang.annotation.Annotation;
 import java.util.List;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 import com.googlecode.androidannotations.annotations.ItemSelect;
 import com.googlecode.androidannotations.rclass.IRClass;
@@ -79,10 +84,17 @@ public class ItemSelectedProcessor extends MultipleResIdsBasedProcessor implemen
 
 		itemSelectedCall.arg(JExpr.TRUE);
 
+		VariableElement secondParameter = parameters.get(1);
+		TypeMirror parameterType = secondParameter.asType();
+
 		if (hasItemParameter) {
-			VariableElement parameter = parameters.get(1);
-			String parameterQualifiedName = parameter.asType().toString();
-			itemSelectedCall.arg(JExpr.cast(holder.refClass(parameterQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+
+			if (parameterType.getKind() == TypeKind.INT) {
+				itemSelectedCall.arg(onItemClickPositionParam);
+			} else {
+				String parameterTypeQualifiedName = parameterType.toString();
+				itemSelectedCall.arg(JExpr.cast(holder.refClass(parameterTypeQualifiedName), JExpr.invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
+			}
 		}
 
 		JMethod onNothingSelectedMethod = onItemSelectedListenerClass.method(JMod.PUBLIC, codeModel.VOID, "onNothingSelected");
@@ -93,7 +105,11 @@ public class ItemSelectedProcessor extends MultipleResIdsBasedProcessor implemen
 
 		nothingSelectedCall.arg(JExpr.FALSE);
 		if (hasItemParameter) {
-			nothingSelectedCall.arg(JExpr._null());
+			if (parameterType.getKind() == TypeKind.INT) {
+				nothingSelectedCall.arg(lit(-1));
+			} else {
+				nothingSelectedCall.arg(_null());
+			}
 		}
 
 		for (JFieldRef idRef : idsRefs) {

--- a/AndroidAnnotations/functional-test-1-5/res/layout/item_clicks_handled.xml
+++ b/AndroidAnnotations/functional-test-1-5/res/layout/item_clicks_handled.xml
@@ -44,5 +44,11 @@
 	    android:layout_width="fill_parent"
 	    android:layout_height="wrap_content"
 	/>
+	
+	<ListView 
+	    android:id="@+id/listViewWithPosition"
+	    android:layout_width="fill_parent"
+	    android:layout_height="wrap_content"
+	/>	
 
 </LinearLayout>

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/ItemClicksHandledActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/ItemClicksHandledActivity.java
@@ -23,6 +23,8 @@ import android.widget.Spinner;
 import com.googlecode.androidannotations.annotations.AfterViews;
 import com.googlecode.androidannotations.annotations.EActivity;
 import com.googlecode.androidannotations.annotations.ItemClick;
+import com.googlecode.androidannotations.annotations.ItemLongClick;
+import com.googlecode.androidannotations.annotations.ItemSelect;
 import com.googlecode.androidannotations.annotations.ViewById;
 
 @EActivity(R.layout.item_clicks_handled)
@@ -77,6 +79,21 @@ public class ItemClicksHandledActivity extends Activity {
 	@ItemClick
 	public void spinnerWithArgument(String selectedItem) {
 		spinnerWithArgumentSelectedItem = selectedItem;
+	}
+	
+	@ItemClick
+	void listViewWithPosition(int position) {
+		
+	}
+	
+	@ItemSelect
+	void listViewWithPositionItemSelected(boolean selected, int position) {
+		
+	}
+	
+	@ItemLongClick
+	void listViewWithPositionItemLongClicked(int position) {
+		
 	}
 
 }


### PR DESCRIPTION
`@ItemClick`, `@ItemLongClick` and `@ItemSelect` methods now have a specific behavior when one use an int parameter : they'll receive the `position` of the selected item instead of the item given by the adapter.

@matboniface Could you check that code? I know this isn't quite what you had in mind, but someone had to implement it :) .

See issue #4
