### PR TITLE
Added support of EAppWidgetProvider annotation

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
@@ -38,6 +38,7 @@ import com.googlecode.androidannotations.annotations.Background;
 import com.googlecode.androidannotations.annotations.BeforeCreate;
 import com.googlecode.androidannotations.annotations.Click;
 import com.googlecode.androidannotations.annotations.EActivity;
+import com.googlecode.androidannotations.annotations.EAppWidgetProvider;
 import com.googlecode.androidannotations.annotations.EProvider;
 import com.googlecode.androidannotations.annotations.EReceiver;
 import com.googlecode.androidannotations.annotations.EService;
@@ -107,6 +108,7 @@ import com.googlecode.androidannotations.processing.BackgroundProcessor;
 import com.googlecode.androidannotations.processing.BeforeCreateProcessor;
 import com.googlecode.androidannotations.processing.ClickProcessor;
 import com.googlecode.androidannotations.processing.EActivityProcessor;
+import com.googlecode.androidannotations.processing.EAppWidgetProviderProcessor;
 import com.googlecode.androidannotations.processing.EProviderProcessor;
 import com.googlecode.androidannotations.processing.EReceiverProcessor;
 import com.googlecode.androidannotations.processing.EServiceProcessor;
@@ -154,6 +156,7 @@ import com.googlecode.androidannotations.validation.AppValidator;
 import com.googlecode.androidannotations.validation.BeforeCreateValidator;
 import com.googlecode.androidannotations.validation.ClickValidator;
 import com.googlecode.androidannotations.validation.EActivityValidator;
+import com.googlecode.androidannotations.validation.EAppWidgetProviderValidator;
 import com.googlecode.androidannotations.validation.EProviderValidator;
 import com.googlecode.androidannotations.validation.EReceiverValidator;
 import com.googlecode.androidannotations.validation.EServiceValidator;
@@ -196,6 +199,7 @@ import com.sun.codemodel.JCodeModel;
 @SupportedAnnotationClasses({ EActivity.class, //
 		App.class, //
 		BeforeCreate.class, //
+		EAppWidgetProvider.class, //
 		EViewGroup.class, //
 		AfterViews.class, //
 		RoboGuice.class, //
@@ -366,6 +370,7 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelValidator.register(new EActivityValidator(processingEnv, rClass, androidManifest));
 		modelValidator.register(new EServiceValidator(processingEnv, androidManifest));
 		modelValidator.register(new EReceiverValidator(processingEnv, androidManifest));
+		modelValidator.register(new EAppWidgetProviderValidator(processingEnv));
 		modelValidator.register(new EProviderValidator(processingEnv, androidManifest));
 		modelValidator.register(new EViewGroupValidator(processingEnv, rClass));
 		modelValidator.register(new EnhancedValidator(processingEnv));
@@ -437,6 +442,7 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelProcessor.register(new EServiceProcessor(processingEnv));
 		modelProcessor.register(new EReceiverProcessor(processingEnv));
 		modelProcessor.register(new EProviderProcessor(processingEnv));
+		modelProcessor.register(new EAppWidgetProviderProcessor(processingEnv));
 		modelProcessor.register(new EViewGroupProcessor(processingEnv, rClass));
 		modelProcessor.register(new EnhancedProcessor(processingEnv));
 		modelProcessor.register(new SharedPrefProcessor(processingEnv));

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/EAppWidgetProvider.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/annotations/EAppWidgetProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2011 Sony Tricoire (sony dot tricoire at gmail.com)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.androidannotations.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Should be used on AppWidgetProvider classes
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface EAppWidgetProvider {
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/AnnotationElements.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/AnnotationElements.java
@@ -16,6 +16,7 @@
 package com.googlecode.androidannotations.model;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Set;
 
 import javax.lang.model.element.Element;
@@ -28,5 +29,8 @@ public interface AnnotationElements {
 	Set<? extends Element> getAnnotatedElements(Class<? extends Annotation> annotationClass);
 
 	TypeElement annotationElementfromAnnotationClass(Class<? extends Annotation> annotationClass);
+
+	Set<? extends Element> getAnnotatedElements(
+			List<Class<? extends Annotation>> annotationClasses);
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/AnnotationElementsHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/AnnotationElementsHolder.java
@@ -18,6 +18,7 @@ package com.googlecode.androidannotations.model;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -68,5 +69,18 @@ public class AnnotationElementsHolder implements AnnotationElements {
 
 		return allElements;
 	}
+	
+	@Override
+    public Set<? extends Element> getAnnotatedElements(List<Class<? extends Annotation>> annotationClasses) {
+        HashSet<Element> result = new HashSet<Element>();
+        for (Class<? extends Annotation> annotationClass : annotationClasses) {
+            TypeElement annotationElement = annotationElementfromAnnotationClass(annotationClass);
+            if (annotationElement != null) {
+                result.addAll(annotatedElementsByAnnotation.get(annotationElement));
+            }
+        }
+
+        return result;
+    }
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/EmptyAnnotationElements.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/model/EmptyAnnotationElements.java
@@ -17,6 +17,7 @@ package com.googlecode.androidannotations.model;
 
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.lang.model.element.Element;
@@ -45,5 +46,10 @@ public class EmptyAnnotationElements implements AnnotationElements {
 	public Set<? extends Element> getAllElements() {
 		return emptySet;
 	}
+	
+	@Override
+    public Set<? extends Element> getAnnotatedElements(List<Class<? extends Annotation>> annotationClasses) {
+        return emptySet;
+    }
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EAppWidgetProviderProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EAppWidgetProviderProcessor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2010-2011 Sony Tricoire (sony dot tricoire at gmail.com)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.androidannotations.processing;
+
+import static com.sun.codemodel.JMod.PRIVATE;
+import static com.sun.codemodel.JMod.PUBLIC;
+
+import java.lang.annotation.Annotation;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+
+import com.googlecode.androidannotations.annotations.EAppWidgetProvider;
+import com.googlecode.androidannotations.helper.AnnotationHelper;
+import com.googlecode.androidannotations.helper.ModelConstants;
+import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JVar;
+
+public class EAppWidgetProviderProcessor extends AnnotationHelper implements ElementProcessor {
+
+    public EAppWidgetProviderProcessor(ProcessingEnvironment processingEnv) {
+        super(processingEnv);
+    }
+
+    @Override
+    public Class<? extends Annotation> getTarget() {
+        return EAppWidgetProvider.class;
+    }
+
+    @Override
+    public void process(Element element, JCodeModel codeModel, EBeansHolder activitiesHolder) throws Exception {
+
+        TypeElement typeElement = (TypeElement) element;
+
+        EBeanHolder holder = activitiesHolder.create(element);
+
+        // AppWidgetProvider
+        String annotatedAppWidgetProviderQualifiedName = typeElement.getQualifiedName().toString();
+
+        String subAppWidgetProviderQualifiedName = annotatedAppWidgetProviderQualifiedName
+                + ModelConstants.GENERATION_SUFFIX;
+
+        int modifiers;
+        boolean isAbstract = element.getModifiers().contains(Modifier.ABSTRACT);
+        if (isAbstract) {
+            modifiers = JMod.PUBLIC | JMod.ABSTRACT;
+        } else {
+            modifiers = JMod.PUBLIC | JMod.FINAL;
+        }
+
+        holder.eBean = codeModel._class(modifiers, subAppWidgetProviderQualifiedName, ClassType.CLASS);
+
+        JClass annotatedAppWidgetProvider = codeModel.directClass(annotatedAppWidgetProviderQualifiedName);
+
+        holder.eBean._extends(annotatedAppWidgetProvider);
+
+        JMethod onEnabled = holder.eBean.method(PUBLIC, codeModel.VOID, "onEnabled");
+        onEnabled.annotate(Override.class);
+
+        JClass contextClass = holder.refClass("android.content.Context");
+        JVar onEnabledContextParam = onEnabled.param(contextClass, "context");
+
+        holder.contextRef = onEnabledContextParam;
+
+        holder.init = holder.eBean.method(PRIVATE, codeModel.VOID, "init_");
+        holder.init.param(contextClass, "context");
+
+        JBlock onEnabledBody = onEnabled.body();
+
+        onEnabledBody.invoke(holder.init).arg(onEnabledContextParam);
+        onEnabledBody.invoke(JExpr._super(), onEnabled).arg(onEnabledContextParam);
+
+    }
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/EAppWidgetProviderValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/EAppWidgetProviderValidator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2011 Pierre-Yves Ricau (py.ricau at gmail.com)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.androidannotations.validation;
+
+import java.lang.annotation.Annotation;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+
+import com.googlecode.androidannotations.annotations.EAppWidgetProvider;
+import com.googlecode.androidannotations.helper.TargetAnnotationHelper;
+import com.googlecode.androidannotations.helper.ValidatorHelper;
+import com.googlecode.androidannotations.model.AnnotationElements;
+
+public class EAppWidgetProviderValidator implements ElementValidator {
+
+    private TargetAnnotationHelper annotationHelper;
+    private ValidatorHelper validatorHelper;
+
+    public EAppWidgetProviderValidator(ProcessingEnvironment processingEnv) {
+        annotationHelper = new TargetAnnotationHelper(processingEnv, getTarget());
+        validatorHelper = new ValidatorHelper(annotationHelper);
+    }
+
+    @Override
+    public Class<? extends Annotation> getTarget() {
+        return EAppWidgetProvider.class;
+    }
+
+    @Override
+    public boolean validate(Element element, AnnotationElements validatedElements) {
+
+        IsValid valid = new IsValid();
+
+        validatorHelper.extendsAppWidgetProvider(element, valid);
+
+        validatorHelper.isNotFinal(element, valid);
+
+        return valid.isValid();
+    }
+}

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/PrefValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/PrefValidator.java
@@ -44,7 +44,7 @@ public class PrefValidator implements ElementValidator {
 
 		IsValid valid = new IsValid();
 
-		validatorHelper.enclosingElementHasEActivity(element, validatedElements, valid);
+		validatorHelper.enclosingElementHasEActivityOrEAppWidgetProvider(element, validatedElements, valid);
 
 		validatorHelper.isNotPrivate(element, valid);
 


### PR DESCRIPTION
I've added a EAppWidgetProvider annotation for AppWidgetProvider subclasses to be able to use Preferences injection.
It cannot be done through @Enhanced because of the context required by shared preferences.
