### PR TITLE
create setRootUrl() method in generated code to change the root REST url

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
@@ -90,6 +90,8 @@ public class ValidatorHelper {
 	private static final String ANDROID_SQLITE_DB_QUALIFIED_NAME = "android.database.sqlite.SQLiteDatabase";
 	private static final String GUICE_INJECTOR_QUALIFIED_NAME = "com.google.inject.Injector";
 	private static final String ROBOGUICE_INJECTOR_PROVIDER_QUALIFIED_NAME = "roboguice.inject.InjectorProvider";
+	
+	private static final String METHOD_NAME_SET_ROOT_URL = "setRootUrl";
 
 	private static final List<String> VALID_PREF_RETURN_TYPES = Arrays.asList("int", "boolean", "float", "long", "java.lang.String");
 
@@ -840,6 +842,7 @@ public class ValidatorHelper {
 		List<? extends Element> enclosedElements = typeElement.getEnclosedElements();
 		boolean foundGetRestTemplateMethod = false;
 		boolean foundSetRestTemplateMethod = false;
+		boolean foundSetRootUrlMethod = false;
 		for (Element enclosedElement : enclosedElements) {
 			if (enclosedElement.getKind() != ElementKind.METHOD) {
 				valid.invalidate();
@@ -881,6 +884,9 @@ public class ValidatorHelper {
 									annotationHelper.printError(enclosedElement, "You can only have oneRestTemplate setter method on a " + TargetAnnotationHelper.annotationName(Rest.class) + " annotated interface");
 
 								}
+							}
+							else if (executableElement.getSimpleName().toString().equals(METHOD_NAME_SET_ROOT_URL) && !foundSetRootUrlMethod) {
+							    foundSetRootUrlMethod = true;
 							} else {
 								valid.invalidate();
 								annotationHelper.printError(enclosedElement, "The method to set a RestTemplate should have only one RestTemplate parameter on a " + TargetAnnotationHelper.annotationName(Rest.class) + " annotated interface");

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/DeleteProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/DeleteProcessor.java
@@ -48,9 +48,8 @@ public class DeleteProcessor extends MethodProcessor {
 
 		Delete deleteAnnotation = element.getAnnotation(Delete.class);
 		String urlSuffix = deleteAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, null, null, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, null, null, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/GetProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/GetProcessor.java
@@ -71,9 +71,8 @@ public class GetProcessor extends MethodProcessor {
 
 		Get getAnnotation = element.getAnnotation(Get.class);
 		String urlSuffix = getAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, expectedClass, generatedReturnType, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, expectedClass, generatedReturnType, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/HeadProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/HeadProcessor.java
@@ -54,9 +54,8 @@ public class HeadProcessor extends MethodProcessor {
 
 		Head headAnnotation = element.getAnnotation(Head.class);
 		String urlSuffix = headAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, expectedClass, expectedClass, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, expectedClass, expectedClass, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/MethodProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/MethodProcessor.java
@@ -72,8 +72,11 @@ public abstract class MethodProcessor implements ElementProcessor {
 		// exchange method call
 		JInvocation restCall = JExpr.invoke(holder.restTemplateField, "exchange");
 
-		// add url param
-		restCall.arg(methodHolder.getUrl());
+		// concat root url + suffix
+		JInvocation concatCall = JExpr.invoke(holder.rootUrlField, "concat");
+
+	    // add url param
+	    restCall.arg(concatCall.arg(JExpr.lit(methodHolder.getUrlSuffix())));
 
 		JClass httpMethod = holder.refClass(ProcessorConstants.HTTP_METHOD);
 		// add method type param

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/MethodProcessorHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/MethodProcessorHolder.java
@@ -27,7 +27,7 @@ import com.sun.codemodel.JVar;
 public class MethodProcessorHolder {
 
 	private Element element;
-	private String url;
+	private String urlSuffix;
 	private JClass expectedClass;
 	private JClass generatedReturnType;
 	private JCodeModel codeModel;
@@ -35,9 +35,9 @@ public class MethodProcessorHolder {
 	private JBlock body;
 	private TreeMap<String, JVar> methodParams;
 
-	public MethodProcessorHolder(Element element, String url, JClass expectedClass, JClass generatedReturnType, JCodeModel codeModel) {
+	public MethodProcessorHolder(Element element, String urlSuffix, JClass expectedClass, JClass generatedReturnType, JCodeModel codeModel) {
 		this.element = element;
-		this.url = url;
+		this.urlSuffix = urlSuffix;
 		this.expectedClass = expectedClass;
 		this.generatedReturnType = generatedReturnType;
 		this.codeModel = codeModel;
@@ -47,8 +47,8 @@ public class MethodProcessorHolder {
 		return element;
 	}
 
-	public String getUrl() {
-		return url;
+	public String getUrlSuffix() {
+		return urlSuffix;
 	}
 
 	public JClass getExpectedClass() {

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/OptionsProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/OptionsProcessor.java
@@ -62,9 +62,8 @@ public class OptionsProcessor extends MethodProcessor {
 
 		Options optionsAnnotation = element.getAnnotation(Options.class);
 		String urlSuffix = optionsAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, expectedClass, generatedReturnType, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, expectedClass, generatedReturnType, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/PostProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/PostProcessor.java
@@ -76,9 +76,8 @@ public class PostProcessor extends MethodProcessor {
 
 		Post postAnnotation = element.getAnnotation(Post.class);
 		String urlSuffix = postAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, expectedClass, generatedReturnType, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, expectedClass, generatedReturnType, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/PutProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/PutProcessor.java
@@ -48,9 +48,8 @@ public class PutProcessor extends MethodProcessor {
 
 		Put putAnnotation = element.getAnnotation(Put.class);
 		String urlSuffix = putAnnotation.value();
-		String url = holder.urlPrefix + urlSuffix;
 
-		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, url, null, null, codeModel));
+		generateRestTemplateCallBlock(new MethodProcessorHolder(executableElement, urlSuffix, null, null, codeModel));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestImplementationHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestImplementationHolder.java
@@ -30,7 +30,7 @@ public class RestImplementationHolder {
 
 	public JFieldVar restTemplateField;
 
-	public String urlPrefix;
+	public JFieldVar rootUrlField;
 
 	public JClass refClass(String fullyQualifiedClassName) {
 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestProcessor.java
@@ -41,7 +41,8 @@ import com.sun.codemodel.JVar;
 
 public class RestProcessor implements ElementProcessor {
 
-	private static final String SPRING_REST_TEMPLATE_QUALIFIED_NAME = "org.springframework.web.client.RestTemplate";
+  private static final String SPRING_REST_TEMPLATE_QUALIFIED_NAME = "org.springframework.web.client.RestTemplate";
+	private static final String JAVA_STRING_QUALIFIED_NAME = "java.lang.String";
 	private final RestImplementationsHolder restImplementationHolder;
 
 	public RestProcessor(RestImplementationsHolder restImplementationHolder) {
@@ -59,9 +60,6 @@ public class RestProcessor implements ElementProcessor {
 		RestImplementationHolder holder = restImplementationHolder.create(element);
 
 		TypeElement typeElement = (TypeElement) element;
-
-		holder.urlPrefix = typeElement.getAnnotation(Rest.class).value();
-
 		String interfaceName = typeElement.getQualifiedName().toString();
 
 		String implementationName = interfaceName + ModelConstants.GENERATION_SUFFIX;
@@ -75,10 +73,15 @@ public class RestProcessor implements ElementProcessor {
 		// RestTemplate field
 		JClass restTemplateClass = holder.refClass(SPRING_REST_TEMPLATE_QUALIFIED_NAME);
 		holder.restTemplateField = holder.restImplementationClass.field(JMod.PRIVATE, restTemplateClass, "restTemplate");
+		
+		// RootUrl field
+		JClass stringClass = holder.refClass(JAVA_STRING_QUALIFIED_NAME);
+        holder.rootUrlField = holder.restImplementationClass.field(JMod.PRIVATE, stringClass, "rootUrl");
 
 		// Default constructor
 		JMethod defaultConstructor = holder.restImplementationClass.constructor(JMod.PUBLIC);
 		defaultConstructor.body().assign(holder.restTemplateField, JExpr._new(restTemplateClass));
+		defaultConstructor.body().assign(holder.rootUrlField, JExpr.lit(typeElement.getAnnotation(Rest.class).value()));
 
 		// RestTemplate constructor
 		JMethod restTemplateConstructor = holder.restImplementationClass.constructor(JMod.PUBLIC);
@@ -120,6 +123,23 @@ public class RestProcessor implements ElementProcessor {
 				}
 			}
 		}
+		
+		// Implement setRootUrl method
+		for (ExecutableElement method : methods) {
+      List<? extends VariableElement> parameters = method.getParameters();
+      if (parameters.size() == 1 && method.getReturnType().getKind() == TypeKind.VOID) {
+        VariableElement firstParameter = parameters.get(0);
+        if (firstParameter.asType().toString().equals(JAVA_STRING_QUALIFIED_NAME) && method.getSimpleName().toString().equals("setRootUrl")) {
+          JMethod setRootUrlMethod = holder.restImplementationClass.method(JMod.PUBLIC, codeModel.VOID, method.getSimpleName().toString());
+          setRootUrlMethod.annotate(Override.class);
+
+          JVar rootUrlSetterParam = setRootUrlMethod.param(stringClass, firstParameter.getSimpleName().toString());
+
+          setRootUrlMethod.body().assign(_this().ref(holder.rootUrlField), rootUrlSetterParam);
+          break; // Only one implementation
+        }
+      }
+    }
 
 	}
 


### PR DESCRIPTION
First off, apologies for all my failed pull requests due to my bumbling around with git.

Hopefully this one should give a good overview of the changes. Here's the text from the original description:

This fix is the second variant proposed in #171. A method setRootUrl() (just like setRestTemplate) can be defined to change the Root URL during runtime. The REST root URL value, if defined, is still set in the generated code.
