### PR TITLE
Restrict TextWatcher method names

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
@@ -1063,5 +1063,12 @@ public class ValidatorHelper {
 		}
 
 	}
+	
+	public void methodHasName(ExecutableElement method, String name, IsValid valid) {
+		if (method.getSimpleName().toString().equals(name)) {
+			valid.invalidate();
+			annotationHelper.printAnnotationError(method, "A method with this annotation cannot have the name \"" + name +  "\". Please rename " + name + "() to something else.");
+		}
+	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/AfterTextChangeValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/AfterTextChangeValidator.java
@@ -63,6 +63,8 @@ public class AfterTextChangeValidator implements ElementValidator {
 		validatorHelper.returnTypeIsVoid(executableElement, valid);
 
 		haveAfterTextChangedMethodParameters(executableElement, valid);
+		
+		validatorHelper.methodHasName(executableElement, "afterTextChanged", valid);
 
 		return valid.isValid();
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/BeforeTextChangeValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/BeforeTextChangeValidator.java
@@ -64,6 +64,8 @@ public class BeforeTextChangeValidator implements ElementValidator {
 		validatorHelper.returnTypeIsVoid(executableElement, valid);
 
 		haveBeforeTextChangedMethodParameters(executableElement, valid);
+		
+		validatorHelper.methodHasName(executableElement, "beforeTextChanged", valid);
 
 		return valid.isValid();
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/TextChangeValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/TextChangeValidator.java
@@ -64,6 +64,8 @@ public class TextChangeValidator implements ElementValidator {
 		validatorHelper.returnTypeIsVoid(executableElement, valid);
 
 		haveTextChangedMethodParameters(executableElement, valid);
+		
+		validatorHelper.methodHasName(executableElement, "onTextChanged", valid);
 
 		return valid.isValid();
 	}


### PR DESCRIPTION
See Issue #214.

Fixed for all 3 Textwatcher methods.
