### PR TITLE
Allowing context constructors for @EBean. 

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/ValidatorHelper.java
@@ -961,6 +961,33 @@ public class ValidatorHelper {
 		}
 	}
 
+	public void hasEmptyOrContextConstructor(Element element, IsValid valid) {
+		List<ExecutableElement> constructors = ElementFilter.constructorsIn(element.getEnclosedElements());
+
+		if (constructors.size() == 1) {
+			ExecutableElement constructor = constructors.get(0);
+
+			if (!annotationHelper.isPrivate(constructor)) {
+				if (constructor.getParameters().size() > 1) {
+					annotationHelper.printAnnotationError(element, "%s annotated element should have a constructor with one parameter max, of type " + CanonicalNameConstants.CONTEXT);
+					valid.invalidate();
+				} else if (constructor.getParameters().size() == 1) {
+					VariableElement parameter = constructor.getParameters().get(0);
+					if (!parameter.asType().toString().equals(CanonicalNameConstants.CONTEXT)) {
+						annotationHelper.printAnnotationError(element, "%s annotated element should have a constructor with one parameter max, of type " + CanonicalNameConstants.CONTEXT);
+						valid.invalidate();
+					}
+				}
+			} else {
+				annotationHelper.printAnnotationError(element, "%s annotated element should not have a private constructor");
+				valid.invalidate();
+			}
+		} else {
+			annotationHelper.printAnnotationError(element, "%s annotated element should have only one constructor");
+			valid.invalidate();
+		}
+	}
+
 	public void hasEmptyConstructor(Element element, IsValid valid) {
 
 		List<ExecutableElement> constructors = ElementFilter.constructorsIn(element.getEnclosedElements());

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EBeanProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EBeanProcessor.java
@@ -25,9 +25,12 @@ import static com.sun.codemodel.JMod.PUBLIC;
 import static com.sun.codemodel.JMod.STATIC;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
 
 import com.googlecode.androidannotations.annotations.EBean;
 import com.googlecode.androidannotations.api.Scope;
@@ -124,6 +127,14 @@ public class EBeanProcessor implements GeneratingElementProcessor {
 			JVar constructorContextParam = constructor.param(classes.CONTEXT, "context");
 
 			JBlock constructorBody = constructor.body();
+
+			List<ExecutableElement> constructors = ElementFilter.constructorsIn(element.getEnclosedElements());
+
+			ExecutableElement superConstructor = constructors.get(0);
+
+			if (superConstructor.getParameters().size() == 1) {
+				constructorBody.invoke("super").arg(constructorContextParam);
+			}
 
 			constructorBody.assign(contextField, constructorContextParam);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/EBeanValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/EBeanValidator.java
@@ -48,7 +48,7 @@ public class EBeanValidator implements ElementValidator {
 
 		validatorHelper.isNotPrivate(element, valid);
 
-		validatorHelper.hasEmptyConstructor(element, valid);
+		validatorHelper.hasEmptyOrContextConstructor(element, valid);
 
 		return valid.isValid();
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/ebean/SomeArrayAdapter.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/ebean/SomeArrayAdapter.java
@@ -1,0 +1,15 @@
+package com.googlecode.androidannotations.test15.ebean;
+
+import android.content.Context;
+import android.widget.ArrayAdapter;
+
+import com.googlecode.androidannotations.annotations.EBean;
+
+@EBean
+public class SomeArrayAdapter extends ArrayAdapter<String> {
+
+	public SomeArrayAdapter(Context context) {
+		super(context, android.R.layout.simple_list_item_1);
+	}
+
+}


### PR DESCRIPTION
See #347

We now allow `@EBean` annotated classes constructor to have a context param if needed
