### PR TITLE
Recreating bean instance only if NonConfigurationInstance Bean is null

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
@@ -460,6 +460,7 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelValidator.register(new FullscreenValidator(processingEnv));
 		modelValidator.register(new RestServiceValidator(processingEnv));
 		modelValidator.register(new RootContextValidator(processingEnv));
+		modelValidator.register(new NonConfigurationInstanceValidator(processingEnv));
 		modelValidator.register(new BeanValidator(processingEnv));
 		modelValidator.register(new AfterInjectValidator(processingEnv));
 		modelValidator.register(new BeforeTextChangeValidator(processingEnv, rClass));
@@ -477,7 +478,6 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelValidator.register(new RunnableValidator(UiThread.class, processingEnv));
 		modelValidator.register(new RunnableValidator(Background.class, processingEnv));
 		modelValidator.register(new InstanceStateValidator(processingEnv));
-		modelValidator.register(new NonConfigurationInstanceValidator(processingEnv));
 		modelValidator.register(new OrmLiteDaoValidator(processingEnv, rClass));
 		modelValidator.register(new HttpsClientValidator(processingEnv, rClass));
 		modelValidator.register(new OnActivityResultValidator(processingEnv, rClass));
@@ -548,6 +548,7 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelProcessor.register(new RestServiceProcessor());
 		modelProcessor.register(new OrmLiteDaoProcessor(processingEnv));
 		modelProcessor.register(new RootContextProcessor());
+		modelProcessor.register(new NonConfigurationInstanceProcessor(processingEnv));
 		modelProcessor.register(new BeanProcessor(processingEnv));
 		modelProcessor.register(new BeforeTextChangeProcessor(processingEnv, rClass));
 		modelProcessor.register(new TextChangeProcessor(processingEnv, rClass));
@@ -567,7 +568,6 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelProcessor.register(new BackgroundProcessor());
 		modelProcessor.register(new AfterInjectProcessor());
 		modelProcessor.register(new InstanceStateProcessor(processingEnv));
-		modelProcessor.register(new NonConfigurationInstanceProcessor(processingEnv));
 		modelProcessor.register(new HttpsClientProcessor(rClass));
 		modelProcessor.register(new OnActivityResultProcessor(processingEnv, rClass));
 		return modelProcessor;

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/NonConfigurationHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/NonConfigurationHolder.java
@@ -22,14 +22,14 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JVar;
 
 public class NonConfigurationHolder {
-	
+
 	public JDefinedClass holderClass;
 
 	public JMethod holderConstructor;
 
 	public JInvocation newHolder;
 
-	public JBlock initIfNonConfiguration;
+	public JBlock initIfNonConfigurationNotNullBody;
 
 	public JVar initNonConfigurationInstance;
 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/NonConfigurationInstanceProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/NonConfigurationInstanceProcessor.java
@@ -95,7 +95,7 @@ public class NonConfigurationInstanceProcessor implements DecoratingElementProce
 				// init()
 				JBlock initBody = holder.init.body();
 				ncHolder.initNonConfigurationInstance = initBody.decl(ncHolder.holderClass, "nonConfigurationInstance", cast(ncHolder.holderClass, _super().invoke(getLastNonConfigurationInstanceName)));
-				ncHolder.initIfNonConfiguration = initBody._if(ncHolder.initNonConfigurationInstance.ne(_null()))._then();
+				ncHolder.initIfNonConfigurationNotNullBody = initBody._if(ncHolder.initNonConfigurationInstance.ne(_null()))._then();
 			}
 
 			{
@@ -134,13 +134,13 @@ public class NonConfigurationInstanceProcessor implements DecoratingElementProce
 
 		ncHolder.newHolder.arg(field);
 
-		ncHolder.initIfNonConfiguration.assign(field, ncHolder.initNonConfigurationInstance.ref(field));
+		ncHolder.initIfNonConfigurationNotNullBody.assign(field, ncHolder.initNonConfigurationInstance.ref(field));
 
 		boolean hasBeanAnnotation = element.getAnnotation(Bean.class) != null;
 		if (hasBeanAnnotation) {
 			JClass fieldGeneratedBeanClass = holder.refClass(fieldType.fullName() + GENERATION_SUFFIX);
 
-			ncHolder.initIfNonConfiguration.invoke(cast(fieldGeneratedBeanClass, field), "rebind").arg(_this());
+			ncHolder.initIfNonConfigurationNotNullBody.invoke(cast(fieldGeneratedBeanClass, field), "rebind").arg(_this());
 		}
 
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/nonconfiguration/NonConfigurationActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/nonconfiguration/NonConfigurationActivity.java
@@ -28,11 +28,14 @@ import com.googlecode.androidannotations.test15.ebean.EmptyDependency;
 @EActivity
 public class NonConfigurationActivity extends Activity {
 
-	@NonConfigurationInstance
 	@Bean
-	public EmptyDependency dependency;
+	@NonConfigurationInstance
+	EmptyDependency maintainedDependency;
+
+	@Bean
+	EmptyDependency recreatedDependency;
 
 	@NonConfigurationInstance
-	public Object someObject;
+	Object someObject;
 
 }


### PR DESCRIPTION
See #354
- Moved the processing order so that the `@NonConfigurationInstance` code is written in the `init_` body **before** the injection of beans
- Added a not null guard to the bean creation instance if it is annotated with  `@NonConfigurationInstance`

So, for instance, the following code:

``` java
@EActivity
public class NonConfigurationActivity extends Activity {

    @Bean
    @NonConfigurationInstance
    EmptyDependency maintainedDependency;

    @Bean
    EmptyDependency recreatedDependency;

    @NonConfigurationInstance
    Object someObject;

}
```

Now generates the following `init_()` method:

``` java
    private void init_(Bundle savedInstanceState) {
        NonConfigurationActivity_.NonConfigurationInstancesHolder nonConfigurationInstance = ((NonConfigurationActivity_.NonConfigurationInstancesHolder) super.getLastNonConfigurationInstance());
        if (nonConfigurationInstance!= null) {
            maintainedDependency = nonConfigurationInstance.maintainedDependency;
            ((EmptyDependency_) maintainedDependency).rebind(this);
            someObject = nonConfigurationInstance.someObject;
        }
        if (maintainedDependency == null) {
            maintainedDependency = EmptyDependency_.getInstance_(this);
        }
        recreatedDependency = EmptyDependency_.getInstance_(this);
    }
```
