### PR TITLE
androidManifestFile pointing to AndroidManifest.xml

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/AndroidManifestFinder.java
@@ -40,7 +40,7 @@ import org.w3c.dom.NodeList;
 
 public class AndroidManifestFinder {
 
-	private static final String ANDROID_MANIFEST_FILE = "androidManifestFile";
+	private static final String ANDROID_MANIFEST_FILE_OPTION = "androidManifestFile";
 
 	private static final int MAX_PARENTS_FROM_SOURCE_FOLDER = 10;
 
@@ -87,7 +87,7 @@ public class AndroidManifestFinder {
 	}
 
 	private File findManifestFileThrowing() throws Exception {
-		if (processingEnv.getOptions().containsKey(ANDROID_MANIFEST_FILE)) {
+		if (processingEnv.getOptions().containsKey(ANDROID_MANIFEST_FILE_OPTION)) {
 			return findManifestInSpecifiedPath();
 		} else {
 			return findManifestInParentsDirectories();
@@ -95,8 +95,8 @@ public class AndroidManifestFinder {
 	}
 
 	private File findManifestInSpecifiedPath() {
-		String path = processingEnv.getOptions().get(ANDROID_MANIFEST_FILE);
-		File androidManifestFile = new File(path, "AndroidManifest.xml");
+		String path = processingEnv.getOptions().get(ANDROID_MANIFEST_FILE_OPTION);
+		File androidManifestFile = new File(path);
 		Messager messager = processingEnv.getMessager();
 		if (!androidManifestFile.exists()) {
 			throw new IllegalStateException("Could not find the AndroidManifest.xml file in specified path : " + path);

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/utils/AAProcessorTestHelper.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/utils/AAProcessorTestHelper.java
@@ -8,8 +8,7 @@ public class AAProcessorTestHelper extends ProcessorTestHelper {
 
 	public void addManifestProcessorParameter(Class<?> classOfPackagingContainingManifest) {
 		String manifestPath = classOfPackagingContainingManifest.getResource("AndroidManifest.xml").getPath();
-		String manifestPackagePath = manifestPath.substring(0, manifestPath.lastIndexOf("/"));
-		addProcessorParameter("androidManifestFile", manifestPackagePath);
+		addProcessorParameter("androidManifestFile", manifestPath);
 	}
 
 	public File toGeneratedFile(Class<?> compiledClass) {


### PR DESCRIPTION
The manifest file processor option now points to the file, not to the directory of the manifest file. 

See #360
