### PR TITLE
RestTemplate converters set in @Rest

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/com/googlecode/androidannotations/annotations/rest/Rest.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/com/googlecode/androidannotations/annotations/rest/Rest.java
@@ -23,5 +23,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
 public @interface Rest {
-	String value() default "";
+	String rootUrl() default "";
+	Class<?>[] converters();
 }

--- a/AndroidAnnotations/androidannotations/pom.xml
+++ b/AndroidAnnotations/androidannotations/pom.xml
@@ -36,6 +36,13 @@
 			<version>1.6_r2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<!-- spring-android-rest-template is required to use the Rest API -->
+			<groupId>org.springframework.android</groupId>
+			<artifactId>spring-android-rest-template</artifactId>
+			<version>1.0.0.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/AndroidAnnotationProcessor.java
@@ -539,7 +539,7 @@ public class AndroidAnnotationProcessor extends AnnotatedAbstractProcessor {
 		modelProcessor.register(new FragmentArgProcessor(processingEnv));
 		modelProcessor.register(new SystemServiceProcessor(androidSystemServices));
 		RestImplementationsHolder restImplementationHolder = new RestImplementationsHolder();
-		modelProcessor.register(new RestProcessor(restImplementationHolder));
+		modelProcessor.register(new RestProcessor(processingEnv, restImplementationHolder));
 		modelProcessor.register(new GetProcessor(processingEnv, restImplementationHolder));
 		modelProcessor.register(new PostProcessor(processingEnv, restImplementationHolder));
 		modelProcessor.register(new PutProcessor(processingEnv, restImplementationHolder));

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/AnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/AnnotationHelper.java
@@ -58,7 +58,6 @@ public class AnnotationHelper {
 	 * be a subtype of itself.
 	 */
 	public boolean isSubtype(TypeMirror potentialSubtype, TypeMirror potentialSupertype) {
-
 		return processingEnv.getTypeUtils().isSubtype(potentialSubtype, potentialSupertype);
 	}
 
@@ -113,6 +112,10 @@ public class AnnotationHelper {
 
 	public boolean isPrivate(Element element) {
 		return element.getModifiers().contains(Modifier.PRIVATE);
+	}
+
+	public boolean isPublic(Element element) {
+		return element.getModifiers().contains(Modifier.PUBLIC);
 	}
 
 	public boolean isAbstract(Element element) {
@@ -308,17 +311,45 @@ public class AnnotationHelper {
 		return target.getSimpleName() + "ed";
 	}
 
-	public DeclaredType extractAnnotationClassParameter(Element element, Class<? extends Annotation> target) {
-
+	public List<DeclaredType> extractAnnotationClassArrayParameter(Element element, Class<? extends Annotation> target, String methodName) {
 		AnnotationMirror annotationMirror = findAnnotationMirror(element, target);
 
 		Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = annotationMirror.getElementValues();
 
 		for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : elementValues.entrySet()) {
 			/*
-			 * "value" is unset when the default value is used
+			 * "methodName" is unset when the default value is used
 			 */
-			if ("value".equals(entry.getKey().getSimpleName().toString())) {
+			if (methodName.equals(entry.getKey().getSimpleName().toString())) {
+
+				AnnotationValue annotationValue = entry.getValue();
+
+				@SuppressWarnings("unchecked")
+				List<AnnotationValue> annotationClassArray = (List<AnnotationValue>) annotationValue.getValue();
+
+				List<DeclaredType> result = new ArrayList<DeclaredType>(annotationClassArray.size());
+
+				for (AnnotationValue annotationClassValue : annotationClassArray) {
+					result.add((DeclaredType) annotationClassValue.getValue());
+				}
+
+				return result;
+			}
+		}
+
+		return null;
+	}
+
+	public DeclaredType extractAnnotationClassParameter(Element element, Class<? extends Annotation> target, String methodName) {
+		AnnotationMirror annotationMirror = findAnnotationMirror(element, target);
+
+		Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = annotationMirror.getElementValues();
+
+		for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : elementValues.entrySet()) {
+			/*
+			 * "methodName" is unset when the default value is used
+			 */
+			if (methodName.equals(entry.getKey().getSimpleName().toString())) {
 
 				AnnotationValue annotationValue = entry.getValue();
 
@@ -329,6 +360,10 @@ public class AnnotationHelper {
 		}
 
 		return null;
+	}
+
+	public DeclaredType extractAnnotationClassParameter(Element element, Class<? extends Annotation> target) {
+		return extractAnnotationClassParameter(element, target, "value");
 	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/helper/CanonicalNameConstants.java
@@ -99,6 +99,7 @@ public final class CanonicalNameConstants {
 	public static final String HTTP_METHOD = "org.springframework.http.HttpMethod";
 	public static final String HTTP_ENTITY = "org.springframework.http.HttpEntity";
 	public static final String REST_TEMPLATE = "org.springframework.web.client.RestTemplate";
+	public static final String HTTP_MESSAGE_CONVERTER = "org.springframework.http.converter.HttpMessageConverter";
 
 	/*
 	 * RoboGuice

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EBeansHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/EBeansHolder.java
@@ -149,6 +149,13 @@ public class EBeansHolder {
 	public EBeansHolder(JCodeModel codeModel) {
 		this.codeModel = codeModel;
 		classes = new Classes();
+		refClass(CanonicalNameConstants.STRING);
+		preloadJavaLangClasses();
+	}
+
+	private void preloadJavaLangClasses() {
+		loadedClasses.put(String.class.getName(), refClass(String.class));
+		loadedClasses.put(Object.class.getName(), refClass(Object.class));
 	}
 
 	public EBeanHolder create(Element element, Class<? extends Annotation> eBeanAnnotation, JDefinedClass generatedClass) {

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/processing/rest/RestProcessor.java
@@ -15,37 +15,45 @@
  */
 package com.googlecode.androidannotations.processing.rest;
 
+import static com.googlecode.androidannotations.helper.CanonicalNameConstants.REST_TEMPLATE;
+import static com.googlecode.androidannotations.helper.CanonicalNameConstants.STRING;
+import static com.sun.codemodel.JExpr._new;
 import static com.sun.codemodel.JExpr._this;
+import static com.sun.codemodel.JExpr.invoke;
+import static com.sun.codemodel.JExpr.lit;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.ElementFilter;
 
 import com.googlecode.androidannotations.annotations.rest.Rest;
+import com.googlecode.androidannotations.helper.AnnotationHelper;
 import com.googlecode.androidannotations.helper.ModelConstants;
 import com.googlecode.androidannotations.processing.EBeansHolder;
 import com.googlecode.androidannotations.processing.GeneratingElementProcessor;
 import com.sun.codemodel.ClassType;
+import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
-import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
 public class RestProcessor implements GeneratingElementProcessor {
 
-	private static final String SPRING_REST_TEMPLATE_QUALIFIED_NAME = "org.springframework.web.client.RestTemplate";
-	private static final String JAVA_STRING_QUALIFIED_NAME = "java.lang.String";
 	private final RestImplementationsHolder restImplementationHolder;
+	private AnnotationHelper annotationHelper;
 
-	public RestProcessor(RestImplementationsHolder restImplementationHolder) {
+	public RestProcessor(ProcessingEnvironment processingEnv, RestImplementationsHolder restImplementationHolder) {
+		annotationHelper = new AnnotationHelper(processingEnv);
 		this.restImplementationHolder = restImplementationHolder;
 	}
 
@@ -71,23 +79,35 @@ public class RestProcessor implements GeneratingElementProcessor {
 		holder.restImplementationClass._implements(interfaceClass);
 
 		// RestTemplate field
-		JClass restTemplateClass = eBeansHolder.refClass(SPRING_REST_TEMPLATE_QUALIFIED_NAME);
+		JClass restTemplateClass = eBeansHolder.refClass(REST_TEMPLATE);
 		holder.restTemplateField = holder.restImplementationClass.field(JMod.PRIVATE, restTemplateClass, "restTemplate");
 
 		// RootUrl field
-		JClass stringClass = eBeansHolder.refClass(JAVA_STRING_QUALIFIED_NAME);
+		JClass stringClass = eBeansHolder.refClass(STRING);
 		holder.rootUrlField = holder.restImplementationClass.field(JMod.PRIVATE, stringClass, "rootUrl");
 
-		// Default constructor
-		JMethod defaultConstructor = holder.restImplementationClass.constructor(JMod.PUBLIC);
-		defaultConstructor.body().assign(holder.restTemplateField, JExpr._new(restTemplateClass));
-		defaultConstructor.body().assign(holder.rootUrlField, JExpr.lit(typeElement.getAnnotation(Rest.class).value()));
+		{
+			// Constructor
+			JMethod constructor = holder.restImplementationClass.constructor(JMod.PUBLIC);
+			JBlock constructorBody = constructor.body();
+			constructorBody.assign(holder.restTemplateField, _new(restTemplateClass));
+
+			{
+				// Converters
+				List<DeclaredType> converters = annotationHelper.extractAnnotationClassArrayParameter(element, getTarget(), "converters");
+				for (DeclaredType converterType : converters) {
+					JClass converterClass = eBeansHolder.refClass(converterType.toString());
+					constructorBody.add(invoke(holder.restTemplateField, "getMessageConverters").invoke("add").arg(_new(converterClass)));
+				}
+			}
+			constructorBody.assign(holder.rootUrlField, lit(typeElement.getAnnotation(Rest.class).rootUrl()));
+		}
 
 		// Implement getRestTemplate method
 		List<? extends Element> enclosedElements = typeElement.getEnclosedElements();
 		List<ExecutableElement> methods = ElementFilter.methodsIn(enclosedElements);
 		for (ExecutableElement method : methods) {
-			if (method.getParameters().size() == 0 && method.getReturnType().toString().equals(SPRING_REST_TEMPLATE_QUALIFIED_NAME)) {
+			if (method.getParameters().size() == 0 && method.getReturnType().toString().equals(REST_TEMPLATE)) {
 				String methodName = method.getSimpleName().toString();
 				JMethod getRestTemplateMethod = holder.restImplementationClass.method(JMod.PUBLIC, restTemplateClass, methodName);
 				getRestTemplateMethod.annotate(Override.class);
@@ -100,7 +120,7 @@ public class RestProcessor implements GeneratingElementProcessor {
 			List<? extends VariableElement> parameters = method.getParameters();
 			if (parameters.size() == 1 && method.getReturnType().getKind() == TypeKind.VOID) {
 				VariableElement firstParameter = parameters.get(0);
-				if (firstParameter.asType().toString().equals(SPRING_REST_TEMPLATE_QUALIFIED_NAME)) {
+				if (firstParameter.asType().toString().equals(REST_TEMPLATE)) {
 					String methodName = method.getSimpleName().toString();
 					JMethod setRestTemplateMethod = holder.restImplementationClass.method(JMod.PUBLIC, codeModel.VOID, methodName);
 					setRestTemplateMethod.annotate(Override.class);
@@ -118,7 +138,7 @@ public class RestProcessor implements GeneratingElementProcessor {
 			List<? extends VariableElement> parameters = method.getParameters();
 			if (parameters.size() == 1 && method.getReturnType().getKind() == TypeKind.VOID) {
 				VariableElement firstParameter = parameters.get(0);
-				if (firstParameter.asType().toString().equals(JAVA_STRING_QUALIFIED_NAME) && method.getSimpleName().toString().equals("setRootUrl")) {
+				if (firstParameter.asType().toString().equals(STRING) && method.getSimpleName().toString().equals("setRootUrl")) {
 					JMethod setRootUrlMethod = holder.restImplementationClass.method(JMod.PUBLIC, codeModel.VOID, method.getSimpleName().toString());
 					setRootUrlMethod.annotate(Override.class);
 

--- a/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/rest/RestValidator.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/com/googlecode/androidannotations/validation/rest/RestValidator.java
@@ -44,7 +44,6 @@ public class RestValidator implements ElementValidator {
 
 	@Override
 	public boolean validate(Element element, AnnotationElements validatedElements) {
-
 		IsValid valid = new IsValid();
 
 		TypeElement typeElement = (TypeElement) element;
@@ -60,6 +59,8 @@ public class RestValidator implements ElementValidator {
 		validatorHelper.doesNotExtendOtherInterfaces(typeElement, valid);
 
 		validatorHelper.unannotatedMethodReturnsRestTemplate(typeElement, valid);
+
+		validatorHelper.validateConverters(element, valid);
 
 		return valid.isValid();
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/AbstractConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/AbstractConverter.java
@@ -1,0 +1,7 @@
+package com.googlecode.androidannotations.rest;
+
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+
+public abstract class AbstractConverter<T> extends AbstractHttpMessageConverter<T> {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClassClient.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClassClient.java
@@ -1,0 +1,8 @@
+package com.googlecode.androidannotations.rest;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = {})
+public class ClassClient {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithAbstractConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithAbstractConverter.java
@@ -1,0 +1,8 @@
+package com.googlecode.androidannotations.rest;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = { AbstractConverter.class })
+public interface ClientWithAbstractConverter {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithNoConverters.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithNoConverters.java
@@ -1,0 +1,8 @@
+package com.googlecode.androidannotations.rest;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = {})
+public interface ClientWithNoConverters {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithNonConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithNonConverter.java
@@ -1,0 +1,8 @@
+package com.googlecode.androidannotations.rest;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = { Object.class })
+public interface ClientWithNonConverter {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithValidConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithValidConverter.java
@@ -1,0 +1,10 @@
+package com.googlecode.androidannotations.rest;
+
+import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = { MappingJacksonHttpMessageConverter.class })
+public interface ClientWithValidConverter {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithWrongConstructorConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/ClientWithWrongConstructorConverter.java
@@ -1,0 +1,8 @@
+package com.googlecode.androidannotations.rest;
+
+import com.googlecode.androidannotations.annotations.rest.Rest;
+
+@Rest(converters = { WrongConstructorConverter.class })
+public interface ClientWithWrongConstructorConverter {
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/RestConverterTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/RestConverterTest.java
@@ -1,0 +1,49 @@
+package com.googlecode.androidannotations.rest;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.googlecode.androidannotations.AndroidAnnotationProcessor;
+import com.googlecode.androidannotations.utils.AAProcessorTestHelper;
+
+public class RestConverterTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setup() {
+		addManifestProcessorParameter(RestConverterTest.class);
+		addProcessor(AndroidAnnotationProcessor.class);
+	}
+
+	@Test
+	public void client_with_no_converters_compiles() {
+		CompileResult result = compileFiles(ClientWithNoConverters.class);
+		assertCompilationSuccessful(result);
+	}
+
+	@Test
+	public void client_with_valid_converter_compiles() {
+		CompileResult result = compileFiles(ClientWithValidConverter.class);
+		assertCompilationSuccessful(result);
+	}
+
+	@Test
+	public void client_with_abstract_converter_does_not_compile() throws IOException {
+		CompileResult result = compileFiles(ClientWithAbstractConverter.class);
+		assertCompilationErrorOn(ClientWithAbstractConverter.class, "@Rest", result);
+	}
+
+	@Test
+	public void client_with_non_converter_does_not_compile() throws IOException {
+		CompileResult result = compileFiles(ClientWithNonConverter.class);
+		assertCompilationErrorOn(ClientWithNonConverter.class, "@Rest", result);
+	}
+
+	@Test
+	public void client_with_wrong_constructor_converter_does_not_compile() throws IOException {
+		CompileResult result = compileFiles(ClientWithWrongConstructorConverter.class);
+		assertCompilationErrorOn(ClientWithWrongConstructorConverter.class, "@Rest", result);
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/RestTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/RestTest.java
@@ -1,0 +1,25 @@
+package com.googlecode.androidannotations.rest;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.googlecode.androidannotations.AndroidAnnotationProcessor;
+import com.googlecode.androidannotations.utils.AAProcessorTestHelper;
+
+public class RestTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setup() {
+		addManifestProcessorParameter(RestTest.class);
+		addProcessor(AndroidAnnotationProcessor.class);
+	}
+
+	@Test
+	public void class_client_does_not_compile() throws IOException {
+		CompileResult result = compileFiles(ClassClient.class);
+		assertCompilationErrorOn(ClassClient.class, "@Rest", result);
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/WrongConstructorConverter.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/com/googlecode/androidannotations/rest/WrongConstructorConverter.java
@@ -1,0 +1,31 @@
+package com.googlecode.androidannotations.rest;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+public class WrongConstructorConverter extends AbstractHttpMessageConverter<String> {
+
+	public WrongConstructorConverter(String someParam) {
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected String readInternal(Class<? extends String> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected void writeInternal(String t, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/resources/com/googlecode/androidannotations/rest/AndroidManifest.xml
+++ b/AndroidAnnotations/androidannotations/src/test/resources/com/googlecode/androidannotations/rest/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2010-2012 eBusiness Information, Excilys Group
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed To in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.googlecode.androidannotations.testprocessor"
+    android:versionCode="1"
+    android:versionName="1.0" >
+
+    <application>
+    </application>
+
+</manifest>

--- a/AndroidAnnotations/functional-test-1-5/pom.xml
+++ b/AndroidAnnotations/functional-test-1-5/pom.xml
@@ -13,7 +13,7 @@
 	<name>functional-test-1-5</name>
 
 	<properties>
-		<spring-android-version>1.0.0.M2</spring-android-version>
+		<spring-android-version>1.0.0.RELEASE</spring-android-version>
 		<jackson-version>1.7.2</jackson-version>
 		<simple-version>2.4.1</simple-version>
 		<android-rome-version>1.0.0-r2</android-rome-version>
@@ -79,12 +79,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<!-- Using ROME for RSS and ATOM feeds -->
-			<groupId>com.google.code.android-rome-feed-reader</groupId>
-			<artifactId>android-rome-feed-reader</artifactId>
-			<version>${android-rome-version}</version>
-		</dependency>
         <dependency>
             <groupId>com.google.android</groupId>
             <artifactId>support-v4</artifactId>
@@ -129,35 +123,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<!-- For developing with Android ROME Feed Reader -->
-		<repository>
-			<id>android-rome-feed-reader-repository</id>
-			<name>Android ROME Feed Reader Repository</name>
-			<url>https://android-rome-feed-reader.googlecode.com/svn/maven2/releases</url>
-		</repository>
-		<!-- For testing against latest Spring snapshots -->
-		<repository>
-			<id>org.springframework.maven.snapshot</id>
-			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<!-- For developing against latest Spring milestones -->
-		<repository>
-			<id>org.springframework.maven.milestone</id>
-			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 
 </project>

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/rest/MyService.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/com/googlecode/androidannotations/test15/rest/MyService.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -33,8 +34,8 @@ import com.googlecode.androidannotations.annotations.rest.Put;
 import com.googlecode.androidannotations.annotations.rest.Rest;
 import com.googlecode.androidannotations.api.rest.MediaType;
 
-@Rest("http://company.com/ajax/services")
-// if defined, the url will be added as a prefix to every request
+// if defined, the rootUrl will be added as a prefix to every request
+@Rest(rootUrl = "http://company.com/ajax/services", converters = { MappingJacksonHttpMessageConverter.class })
 public interface MyService {
 
 	// url variables are mapped to method parameter names.
@@ -56,13 +57,16 @@ public interface MyService {
 	 * You may (or may not) declare throwing RestClientException (as a reminder,
 	 * since it's a RuntimeException), but nothing else.
 	 */
-	ResponseEntity<EventList> getEvents2(String location, int year) throws RestClientException;
+	ResponseEntity<EventList> getEvents2(String location, int year)
+			throws RestClientException;
 
 	@Get("/events/{year}/{location}")
-	ResponseEntity<Event[]> getEventsArray2(String location, int year) throws RestClientException;
+	ResponseEntity<Event[]> getEventsArray2(String location, int year)
+			throws RestClientException;
 
 	@Get("/events/{year}/{location}")
-	ResponseEntity<Event[][]> getEventsArrayOfArrays2(String location, int year) throws RestClientException;
+	ResponseEntity<Event[][]> getEventsArrayOfArrays2(String location, int year)
+			throws RestClientException;
 
 	// There should be max 1 parameter that is not mapped to an attribute. This
 	// parameter will be used as the post entity.

--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -41,10 +41,20 @@
 			</roles>
 		</developer>
 		<developer>
+			<id>mat.boniface</id>
+			<name>Mathieu Boniface	</name>
+			<email>mat.boniface@gmail.com</email>
+			<organization>eBusiness Information</organization>
+			<organizationUrl>http://www.ebusinessinformation.fr</organizationUrl>
+			<roles>
+				<role>Committer</role>
+			</roles>
+		</developer>
+		<developer>
 			<id>athomas.nc</id>
 			<name>Alexandre Thomas</name>
 			<email>athomas.nc@gmail.com</email>
-			<url>http://twitter.com/twikeuk</url>
+			<url>http://twitter.com/AleksThomas</url>
 			<organization>eBusiness Information</organization>
 			<organizationUrl>http://www.ebusinessinformation.fr</organizationUrl>
 			<roles>
@@ -65,16 +75,6 @@
 			<id>bluepyth</id>
 			<name>Romain Sertelon</name>
 			<email>bluepyth@gmail.com</email>
-			<organization>eBusiness Information</organization>
-			<organizationUrl>http://www.ebusinessinformation.fr</organizationUrl>
-			<roles>
-				<role>Committer</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>mat.boniface</id>
-			<name>Mathieu Boniface	</name>
-			<email>mat.boniface@gmail.com</email>
 			<organization>eBusiness Information</organization>
 			<organizationUrl>http://www.ebusinessinformation.fr</organizationUrl>
 			<roles>


### PR DESCRIPTION
See #206.

We're updating AndroidAnnotations to work with RestTemplate `1.0.0.RELEASE`. This means that we must accomodate to the changes. One of these changes is that `RestTemplate` default constructor now comes with no converters. So we must reflect that on the API, by forcing the user to explicitly declare the converters to use, because the most common case is to actually use converters.

`@Rest` now holds a new `converters()` parameter on which one can define the converter classes to use. The `value()` parameter has been renamed to `rootUrl()` and is still optional.

Usage example:

``` java
@Rest(rootUrl = "http://company.com/ajax/services", converters = { MappingJacksonHttpMessageConverter.class })
public interface MyService {
}
```
