### PR TITLE
Changing processing order, ancestors first

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/ModelProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/ModelProcessor.java
@@ -88,6 +88,22 @@ public class ModelProcessor {
 		for (DecoratingElementProcessor processor : enclosedProcessors) {
 			Class<? extends Annotation> target = processor.getTarget();
 
+			/*
+			 * For ancestors, the processor manipulates the annotated elements,
+			 * but uses the holder for the root element
+			 */
+			Set<AnnotatedAndRootElements> ancestorAnnotatedElements = validatedModel.getAncestorAnnotatedElements(target.getName());
+			for (AnnotatedAndRootElements elements : ancestorAnnotatedElements) {
+				EBeanHolder holder = eBeansHolder.getEBeanHolder(elements.rootTypeElement);
+				/*
+				 * Annotations coming from ancestors may be applied to root
+				 * elements that are not validated, and therefore not available.
+				 */
+				if (holder != null) {
+					processor.process(elements.annotatedElement, codeModel, holder);
+				}
+			}
+
 			Set<? extends Element> rootAnnotatedElements = validatedModel.getRootAnnotatedElements(target.getName());
 
 			for (Element annotatedElement : rootAnnotatedElements) {
@@ -109,21 +125,6 @@ public class ModelProcessor {
 				}
 			}
 
-			/*
-			 * For ancestors, the processor manipulates the annotated elements,
-			 * but uses the holder for the root element
-			 */
-			Set<AnnotatedAndRootElements> ancestorAnnotatedElements = validatedModel.getAncestorAnnotatedElements(target.getName());
-			for (AnnotatedAndRootElements elements : ancestorAnnotatedElements) {
-				EBeanHolder holder = eBeansHolder.getEBeanHolder(elements.rootTypeElement);
-				/*
-				 * Annotations coming from ancestors may be applied to root
-				 * elements that are not validated, and therefore not available.
-				 */
-				if (holder != null) {
-					processor.process(elements.annotatedElement, codeModel, holder);
-				}
-			}
 		}
 
 		return new ProcessResult(//

--- a/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/inheritance/InheritanceTest.java
+++ b/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/inheritance/InheritanceTest.java
@@ -1,0 +1,29 @@
+package org.androidannotations.test15.inheritance;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.androidannotations.test15.AndroidAnnotationsTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.app.Activity;
+import android.content.Context;
+
+@RunWith(AndroidAnnotationsTestRunner.class)
+public class InheritanceTest {
+
+	@Test
+	public void after_inject_mother_calls_first() {
+		Child child = Child_.getInstance_(mock(Context.class));
+		assertThat(child.motherInitWasCalled).isTrue();
+	}
+	
+	@Test
+	public void after_views_mother_calls_first() {
+		Child_ child = Child_.getInstance_(mock(Activity.class));
+		child.afterSetContentView_();
+		assertThat(child.motherInitViewsWasCalled).isTrue();
+	}
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/inheritance/Child.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/inheritance/Child.java
@@ -1,0 +1,23 @@
+package org.androidannotations.test15.inheritance;
+
+import org.androidannotations.annotations.AfterInject;
+import org.androidannotations.annotations.AfterViews;
+import org.androidannotations.annotations.EBean;
+
+@EBean
+public class Child extends Mother {
+
+	public boolean motherInitWasCalled;
+	public boolean motherInitViewsWasCalled;
+
+	@AfterInject
+	void initChild() {
+		motherInitWasCalled = motherInitCalled;
+	}
+
+	@AfterViews
+	void initViewsChild() {
+		motherInitViewsWasCalled = motherInitViewsCalled;
+	}
+
+}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/inheritance/Mother.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/inheritance/Mother.java
@@ -1,0 +1,23 @@
+package org.androidannotations.test15.inheritance;
+
+import org.androidannotations.annotations.AfterInject;
+import org.androidannotations.annotations.AfterViews;
+import org.androidannotations.annotations.EBean;
+
+@EBean
+public abstract class Mother {
+
+	protected boolean motherInitCalled = false;
+	protected boolean motherInitViewsCalled = false;
+
+	@AfterInject
+	void initMother() {
+		motherInitCalled = true;
+	}
+	
+	@AfterViews
+	void initViewsMother() {
+		motherInitViewsCalled = true;
+	}
+
+}


### PR DESCRIPTION
See #296

We are now processing the ancestors elements first, so that `@AfterInject` and `@AfterViews` in parent classes are called first.
