### PR TITLE
Fix assertCompilationDiagnostingOn so that it doesn't improperly fail

### DIFF
--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/ProcessorTestHelper.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/ProcessorTestHelper.java
@@ -151,13 +151,7 @@ public class ProcessorTestHelper {
 						CharSequence sourceContent = source.getCharContent(true);
 						if (diagnostic.getPosition() != Diagnostic.NOPOS) {
 							CharSequence contentInError = sourceContent.subSequence((int) diagnostic.getStartPosition(), (int) diagnostic.getEndPosition());
-							String contentInErrorString = contentInError.toString();
-							int parenIndex = contentInErrorString.indexOf("(");
-							if (parenIndex != -1)
-							{
-								    contentInErrorString = contentInErrorString.substring(0, parenIndex);
-							}
-							if (expectedContentInError.equals(contentInErrorString)) {
+							if (contentInError.toString().contains(expectedContentInError)) {
 								return;
 							}
 						}


### PR DESCRIPTION
This should fix an issue where org.androidannotations.rest.RestConverterTest would fail improperly.

When calling assertCompilationDiagnostingOn with @Rest the diagnostics class was returning contentInError like so:
@Rest(converters = { AbstractConverter.class })
@Rest(converters = { Object.class })
@Rest(converters = { WrongConstructorConverter.class })
But the test expected @Rest

There may be a better way to fix this but this got the job done.
