### PR TITLE
Users can now use an url with a parameter declared twice in annotations related to Rest API

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/RestAnnotationHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/RestAnnotationHelper.java
@@ -17,7 +17,9 @@ package org.androidannotations.helper;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,7 +35,7 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 		super(processingEnv, target);
 	}
 
-	public void urlVariableNamesExistInParameters(ExecutableElement element, List<String> variableNames, IsValid valid) {
+	public void urlVariableNamesExistInParameters(ExecutableElement element, Set<String> variableNames, IsValid valid) {
 
 		List<? extends VariableElement> parameters = element.getParameters();
 
@@ -53,7 +55,7 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 
 	public void urlVariableNamesExistInParametersAndHasNoOneMoreParameter(ExecutableElement element, IsValid valid) {
 		if (valid.isValid()) {
-			List<String> variableNames = extractUrlVariableNames(element);
+			Set<String> variableNames = extractUrlVariableNames(element);
 			urlVariableNamesExistInParameters(element, variableNames, valid);
 			if (valid.isValid()) {
 				List<? extends VariableElement> parameters = element.getParameters();
@@ -65,10 +67,10 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 			}
 		}
 	}
-	
+
 	public void urlVariableNamesExistInParametersAndHasOnlyOneMoreParameter(ExecutableElement element, IsValid valid) {
 		if (valid.isValid()) {
-			List<String> variableNames = extractUrlVariableNames(element);
+			Set<String> variableNames = extractUrlVariableNames(element);
 			urlVariableNamesExistInParameters(element, variableNames, valid);
 			if (valid.isValid()) {
 				List<? extends VariableElement> parameters = element.getParameters();
@@ -84,7 +86,7 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 	/** Captures URI template variable names. */
 	private static final Pattern NAMES_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
 
-	public List<String> extractUrlVariableNames(ExecutableElement element) {
+	public Set<String> extractUrlVariableNames(ExecutableElement element) {
 
 		// extract variables name from root url isn't really useful
 
@@ -94,7 +96,7 @@ public class RestAnnotationHelper extends TargetAnnotationHelper {
 		// String urlSuffix = extractAnnotationValue(element);
 		// String uriTemplate = urlPrefix + urlSuffix;
 
-		List<String> variableNames = new ArrayList<String>();
+		Set<String> variableNames = new HashSet<String>();
 		String uriTemplate = extractAnnotationValueParameter(element);
 
 		boolean hasValueInAnnotation = uriTemplate != null;

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/MethodProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/MethodProcessor.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -30,8 +31,9 @@ import javax.lang.model.element.VariableElement;
 import org.androidannotations.annotations.rest.Accept;
 import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.helper.RestAnnotationHelper;
-import org.androidannotations.processing.EBeanHolder;
 import org.androidannotations.processing.DecoratingElementProcessor;
+import org.androidannotations.processing.EBeanHolder;
+
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
@@ -127,13 +129,14 @@ public abstract class MethodProcessor implements DecoratingElementProcessor {
 		TreeMap<String, JVar> methodParams = methodHolder.getMethodParams();
 		JVar hashMapVar = null;
 
-		List<String> urlVariables = restAnnotationHelper.extractUrlVariableNames(element);
+		Set<String> urlVariables = restAnnotationHelper.extractUrlVariableNames(element);
 		JClass hashMapClass = codeModel.ref(HashMap.class).narrow(String.class, Object.class);
 		if (!urlVariables.isEmpty()) {
 			hashMapVar = body.decl(hashMapClass, "urlVariables", JExpr._new(hashMapClass));
 
 			for (String urlVariable : urlVariables) {
-				body.invoke(hashMapVar, "put").arg(urlVariable).arg(methodParams.get(urlVariable));
+				JVar urlValue = methodParams.get(urlVariable);
+				body.invoke(hashMapVar, "put").arg(urlVariable).arg(urlValue);
 				methodParams.remove(urlVariable);
 			}
 		}

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/MyService.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/MyService.java
@@ -47,6 +47,11 @@ public interface MyService {
 	@Accept("application/json")
 	Event[] getEventsArray(String location, int year);
 
+
+	@Get("/events/{year}/{year}")
+	@Accept(MediaType.APPLICATION_JSON)
+	Event[][] urlWithAParameterDeclaredTwice(int year);
+
 	@Get("/events/{year}/{location}")
 	@Accept(MediaType.APPLICATION_JSON)
 	Event[][] getEventsArrayOfArrays(String location, int year);


### PR DESCRIPTION
See #390
