### PR TITLE
Expose the shared pref key

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/api/sharedpreferences/AbstractPrefField.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/api/sharedpreferences/AbstractPrefField.java
@@ -32,6 +32,10 @@ public abstract class AbstractPrefField {
 		return sharedPreferences.contains(key);
 	}
 
+	public String key() {
+		return this.key;
+	}
+
 	public final void remove() {
 		apply(edit().remove(key));
 	}


### PR DESCRIPTION
This is useful in particular when observing sharedPreferences changes:

``` java
@Override
public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
    if (prefs.myPref().key().equals(key) {
        // Do stuff
    }
}
```
