### PR TITLE
@ItemClick and type parameters workaround

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/ItemClickProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/ItemClickProcessor.java
@@ -91,6 +91,8 @@ public class ItemClickProcessor implements DecoratingElementProcessor {
 				itemClickCall.arg(onItemClickPositionParam);
 			} else {
 				String parameterTypeQualifiedName = parameterType.toString();
+				/* Workaround a CodeModel bug when type have parameters */
+				parameterTypeQualifiedName = parameterTypeQualifiedName.replaceFirst("<.*", "");
 				itemClickCall.arg(cast(holder.refClass(parameterTypeQualifiedName), invoke(onItemClickParentParam, "getAdapter").invoke("getItem").arg(onItemClickPositionParam)));
 			}
 		}


### PR DESCRIPTION
This piece of code does not generate compilable code (see #504):

``` java
    @ItemClick
    void listItemClicked(List<String> item) {}
```

I think the problem comes from CodeModel.

I propose a workaround which generates compilable code (but with a type safety warning).
