### PR TITLE
Propagate exceptions on @Background/@UIThread annotated methods

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
@@ -228,7 +228,7 @@ public class APTCodeModelHelper {
 		throw new IllegalStateException("Unable to extract target name from JFieldRef");
 	}
 
-	public JTryBlock surroundWithTryCatch(EBeanHolder holder, JBlock block, JBlock content, String exceptionMessage) {
+	public JTryBlock surroundWithTryCatch(EBeanHolder holder, JBlock block, JBlock content, String exceptionMessage, boolean propagate) {
 		Classes classes = holder.classes();
 		JTryBlock tryBlock = block._try();
 		tryBlock.body().add(content);
@@ -239,6 +239,9 @@ public class APTCodeModelHelper {
 		errorInvoke.arg(exceptionMessage);
 		errorInvoke.arg(exceptionParam);
 		catchBlock.body().add(errorInvoke);
+		if (propagate) {
+			catchBlock.body()._throw(exceptionParam);
+		}
 		return tryBlock;
 	}
 
@@ -257,7 +260,7 @@ public class APTCodeModelHelper {
 
 		JBlock runMethodBody = runMethod.body();
 
-		surroundWithTryCatch(holder, runMethodBody, previousMethodBody, "A runtime exception was thrown while executing code in a runnable");
+		surroundWithTryCatch(holder, runMethodBody, previousMethodBody, "A runtime exception was thrown while executing code in a runnable", true);
 
 		return anonymousRunnableClass;
 	}

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/BackgroundProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/BackgroundProcessor.java
@@ -61,7 +61,7 @@ public class BackgroundProcessor implements DecoratingElementProcessor {
 		executeMethod.annotate(Override.class);
 
 		JBlock runMethodBody = executeMethod.body();
-		helper.surroundWithTryCatch(holder, runMethodBody, previousMethodBody, "A runtime exception was thrown while executing code in a background task");
+		helper.surroundWithTryCatch(holder, runMethodBody, previousMethodBody, "A runtime exception was thrown while executing code in a background task", true);
 
 		Background annotation = element.getAnnotation(Background.class);
 		String id = annotation.id();

--- a/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/ThreadActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/ThreadActivityTest.java
@@ -263,4 +263,26 @@ public class ThreadActivityTest {
 		}
 	}
 
+	@Test
+	public void propagateException() {
+		BackgroundExecutor.setExecutor(new Executor() {
+			@Override
+			public void execute(Runnable command) {
+				command.run();
+			}
+		});
+		try {
+			activity.backgroundThrowException();
+			Assert.fail("Exception should be propagated in @Background annotated methods");
+		} catch (RuntimeException e) {
+			// good
+		}
+		try {
+			activity.uiThreadThrowException();
+			Assert.fail("Exception should be propagated in @UIThread annotated methods");
+		} catch (RuntimeException e) {
+			// good
+		}
+	}
+
 }

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/ThreadActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/ThreadActivity.java
@@ -139,4 +139,14 @@ public class ThreadActivity extends Activity {
 	@Background
 	void backgroundUsingArrayParamtersMethod(MySerializableBean[][] array) {
 	}
+
+	@Background
+	void backgroundThrowException() {
+		throw new RuntimeException();
+	}
+
+	@UiThread
+	void uiThreadThrowException() {
+		throw new RuntimeException();
+	}
 }


### PR DESCRIPTION
Related to #646

Instead of only logging the exceptions thrown in `@Background`/`@UIThread` blocks, which make them invisibles to exception handlers, a decision has been made to propagate them. 

Requires a big warning in the 3.0 change log :smile: 

The generated code : 

``` java
 @Override
    public void emptyBackgroundMethod() {
        BackgroundExecutor.execute(new BackgroundExecutor.Task("", 0, "") {


            @Override
            public void execute() {
                try {
                    ThreadActivity_.super.emptyBackgroundMethod();
                } catch (RuntimeException e) {
                    Log.e("ThreadActivity_", "A runtime exception was thrown while executing code in a background task", e);
                    throw e;
                }
            }

        }
        );
    }
```
