### PR TITLE
Log a warning when a @RootContext field isn't populated

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/RootContextProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/RootContextProcessor.java
@@ -16,6 +16,7 @@
 package org.androidannotations.processing;
 
 import static com.sun.codemodel.JExpr.cast;
+import static com.sun.codemodel.JExpr.lit;
 import static com.sun.codemodel.JExpr.ref;
 import static org.androidannotations.helper.CanonicalNameConstants.CONTEXT;
 
@@ -27,6 +28,9 @@ import org.androidannotations.annotations.RootContext;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JConditional;
+import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JInvocation;
 
 public class RootContextProcessor implements DecoratingElementProcessor {
 
@@ -49,10 +53,16 @@ public class RootContextProcessor implements DecoratingElementProcessor {
 			body.assign(ref(fieldName), holder.contextRef);
 		} else {
 			JClass extendingContextClass = holder.refClass(typeQualifiedName);
-			body._if(holder.contextRef._instanceof(extendingContextClass)) //
-					._then() //
+			JConditional cond = body._if(holder.contextRef._instanceof(extendingContextClass));
+			cond._then() //
 					.assign(ref(fieldName), cast(extendingContextClass, holder.contextRef));
+
+			JInvocation warningInvoke = holder.classes().LOG.staticInvoke("w");
+			warningInvoke.arg(holder.generatedClass.name());
+			JExpression expr = lit("Due to Context class ").plus(holder.contextRef.invoke("getClass").invoke("getSimpleName")).plus(lit(", the @RootContext " + extendingContextClass.name() + " won't be populated"));
+			warningInvoke.arg(expr);
+			cond._else() //
+					.add(warningInvoke);
 		}
 	}
-
 }


### PR DESCRIPTION
Related to #674 

When a bean is injected in another class which has a different Context
from the required @RootContext field class, the field is left null. This
could produce hard to find bugs. The fix adds a log to warn the user.

The generated code from `EnhancedClass_` : 

``` java
 @SuppressWarnings("all")
    private void init_() {
        if (context_ instanceof Activity) {
            Activity activity = ((Activity) context_);
        }
        OnViewChangedNotifier.registerOnViewChangedListener(this);
        Resources resources_ = context_.getResources();
        hello = resources_.getString(string.hello);
        activityManager = ((ActivityManager) context_.getSystemService(Context.ACTIVITY_SERVICE));
        customApplication = SampleRoboApplication_.getInstance();
        if (context_ instanceof ThreadActivity) {
            threadActivity = ((ThreadActivity) context_);
        } else {
            Log.w("EnhancedClass_", (("Due to Context class "+ context_.getClass().getSimpleName())+", the @RootContext ThreadActivity won't be populated"));
        }
        context = context_;
        if (context_ instanceof Service) {
            service = ((Service) context_);
        } else {
            Log.w("EnhancedClass_", (("Due to Context class "+ context_.getClass().getSimpleName())+", the @RootContext Service won't be populated"));
        }
        if (context_ instanceof Activity) {
            activity = ((Activity) context_);
        } else {
            Log.w("EnhancedClass_", (("Due to Context class "+ context_.getClass().getSimpleName())+", the @RootContext Activity won't be populated"));
        }
        secondDependency = SecondDependency_.getInstance_(context_);
        calledAfterInjection();
    }
```

I don't know very well Codemodel yet, please check if I used it well.
