### PR TITLE
475 add missing rest authentication

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/DeleteProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/DeleteProcessor.java
@@ -23,6 +23,7 @@ import org.androidannotations.annotations.rest.Delete;
 import org.androidannotations.processing.EBeanHolder;
 
 import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JInvocation;
 
 public class DeleteProcessor extends MethodProcessor {
 
@@ -46,4 +47,8 @@ public class DeleteProcessor extends MethodProcessor {
 		generateRestTemplateCallBlock(new MethodProcessorHolder(holder, executableElement, urlSuffix, null, null, codeModel));
 	}
 
+	@Override
+	protected JInvocation addHttpEntityVar(JInvocation restCall, MethodProcessorHolder methodHolder) {
+		return restCall.arg(generateHttpEntityVar(methodHolder));
+	}
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/HeadProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/HeadProcessor.java
@@ -27,6 +27,7 @@ import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JInvocation;
 
 public class HeadProcessor extends MethodProcessor {
 
@@ -52,6 +53,11 @@ public class HeadProcessor extends MethodProcessor {
 		String urlSuffix = headAnnotation.value();
 
 		generateRestTemplateCallBlock(new MethodProcessorHolder(holder, executableElement, urlSuffix, expectedClass, expectedClass, codeModel));
+	}
+
+	@Override
+	protected JInvocation addHttpEntityVar(JInvocation restCall, MethodProcessorHolder methodHolder) {
+		return restCall.arg(generateHttpEntityVar(methodHolder));
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/OptionsProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/rest/OptionsProcessor.java
@@ -29,6 +29,7 @@ import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JInvocation;
 
 public class OptionsProcessor extends MethodProcessor {
 
@@ -60,6 +61,11 @@ public class OptionsProcessor extends MethodProcessor {
 		String urlSuffix = optionsAnnotation.value();
 
 		generateRestTemplateCallBlock(new MethodProcessorHolder(holder, executableElement, urlSuffix, expectedClass, generatedReturnType, codeModel));
+	}
+
+	@Override
+	protected JInvocation addHttpEntityVar(JInvocation restCall, MethodProcessorHolder methodHolder) {
+		return restCall.arg(generateHttpEntityVar(methodHolder));
 	}
 
 	@Override

--- a/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/rest/MyServiceTest.java
+++ b/AndroidAnnotations/functional-test-1-5-tests/src/test/java/org/androidannotations/test15/rest/MyServiceTest.java
@@ -242,7 +242,9 @@ public class MyServiceTest {
 		String xtValue = "1234";
 		String sjsaidValue = "5678";
 
-		myService.setHeader("SomeFancyHeader", "fancyHeaderToken");
+		final String fancyHeaderName = "SomeFancyHeader";
+		final String fancyToken = "fancyHeaderToken";
+		myService.setHeader(fancyHeaderName, fancyToken);
 		
 		addPendingResponse("[]", "xt", xtValue, "sjsaid", sjsaidValue);
 		myService.authenticate();
@@ -250,5 +252,20 @@ public class MyServiceTest {
 		assertEquals(xtValue, myService.getCookie("xt"));
 		assertEquals(sjsaidValue, myService.getCookie("sjsaid"));
 
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		myService.setRestTemplate(restTemplate);
+
+		// deletes
+        ArgumentMatcher<HttpEntity<Void>> matcher = new ArgumentMatcher<HttpEntity<Void>>() {
+
+			@Override
+			public boolean matches(Object argument) {
+				final String expected = fancyToken;
+				return expected.equals(((HttpEntity<?>) argument).getHeaders().get(fancyHeaderName).get(0));
+			}
+		};
+		addPendingResponse("");
+		myService.removeEvent(0);
+		verify(restTemplate).exchange(Mockito.anyString(), eq(HttpMethod.DELETE), argThat(matcher), Mockito.<Class<Object>> any(), Mockito.<Map<String, ?>> any());
 	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/MyService.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/MyService.java
@@ -199,6 +199,7 @@ public interface MyService {
 
 	// url variables are mapped to method parameter names.
 	@Delete("/events/{id}")
+	@RequiresHeader("SomeFancyHeader")
 	void removeEvent(long id);
 
 	// *** HEAD ***


### PR DESCRIPTION
The Delete/Head/Options methods were not being processed properly for the `@RequiresHeader` annotation (or, really, anything that used the `HttpEntity`). This pull request should fix that. 

(See #475)
