### PR TITLE
Generics support for generated fragments

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ThirdPartyLibHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/ThirdPartyLibHelper.java
@@ -35,7 +35,7 @@ public class ThirdPartyLibHelper {
 	 * types
 	 */
 	public boolean usesHoloEverywhere(EBeanHolder holder) {
-		TypeElement typeElement = annotationHelper.typeElementFromQualifiedName(holder.generatedClass._extends().fullName());
+		TypeElement typeElement = annotationHelper.typeElementFromQualifiedName(holder.generatedClass._extends().erasure().fullName());
 
 		TypeMirror superType;
 		while (!((superType = typeElement.getSuperclass()) instanceof NoType)) {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/FragmentArgProcessor.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/FragmentArgProcessor.java
@@ -24,6 +24,7 @@ import static com.sun.codemodel.JMod.PUBLIC;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import org.androidannotations.annotations.FragmentArg;
@@ -113,7 +114,8 @@ public class FragmentArgProcessor implements DecoratingElementProcessor {
 		containsKeyCatch.body().add(logError);
 
 		{
-			JMethod method = holder.fragmentBuilderClass.method(PUBLIC, holder.fragmentBuilderClass, fieldName);
+			JClass returnClass = GenericUtils.generifyAs(codeModel, (TypeElement) element.getEnclosingElement(), holder.fragmentBuilderClass);
+			JMethod method = holder.fragmentBuilderClass.method(PUBLIC, returnClass, fieldName);
 
 			JClass paramClass = helper.typeMirrorToJClass(elementType, holder);
 			JVar arg = method.param(paramClass, fieldName);

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/GenericUtils.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/processing/GenericUtils.java
@@ -1,0 +1,26 @@
+package org.androidannotations.processing;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JGenerifiable;
+
+public class GenericUtils {
+
+	public static void generifyAs(TypeElement template, JGenerifiable generifiable) {
+		for (TypeParameterElement typeParameterElement : template.getTypeParameters()) {
+			generifiable.generify(typeParameterElement.getSimpleName().toString());
+		}
+	}
+
+	public static JClass generifyAs(JCodeModel codeModel, TypeElement template, JClass clazz) {
+		for (TypeParameterElement typeParameterElement : template.getTypeParameters()) {
+			clazz = clazz.narrow(codeModel.ref(typeParameterElement.getSimpleName().toString()));
+		}
+		
+		return clazz;
+	}
+
+}


### PR DESCRIPTION
I stumbled over a non-compiling code when annotating with @EFragment a Fragment with a type parameter. This change should make generated fragments use the same type parameters as the original one. Please let me know if there is a better way; it's my first encounter with Code Model and annotation processing.
