### PR TITLE
Propagate exceptions for submitted/scheduled tasks

### DIFF
--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/ThreadActivity.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/ThreadActivity.java
@@ -29,7 +29,6 @@ import org.androidannotations.test15.ebean.SomeBean;
 import org.androidannotations.test15.instancestate.MySerializableBean;
 
 import android.app.Activity;
-import android.os.Looper;
 
 @EActivity
 public class ThreadActivity extends Activity {
@@ -142,6 +141,11 @@ public class ThreadActivity extends Activity {
 
 	@Background
 	void backgroundThrowException() {
+		throw new RuntimeException();
+	}
+
+	@Background(delay = 100)
+	void backgroundDelayThrowException() {
 		throw new RuntimeException();
 	}
 


### PR DESCRIPTION
Fix improvement for #646 

For remind, the goal of #646 was to stop catching exception in `@Backgound` annotated methods, in order to let the user deals with it. 

First shot was to simply remove the try/catch blocks, but as discussed [here](https://github.com/excilys/androidannotations/pull/677#issuecomment-21859232), there is a problem because `ExecutorService.submit/schedule` doesn't propagate exception during executions. This is _by design_. As a result, exceptions thrown are not logged and not visible.

To handle that, I suggest a solution :
Call `futur.get()` (in another thread pool) to check if an exception occurred during execution. If yes then throw it so it could be caught by the system.

I admit it looks like a nasty trick, but I didn't find a better solution. If someone has, I will be happy to read it.
