### PR TITLE
Adding setBearerAuth(String) to RestClientHeaders interface

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/rest/RestClientHeaders.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/rest/RestClientHeaders.java
@@ -69,4 +69,11 @@ public interface RestClientHeaders {
 	 * @param password
 	 */
 	void setHttpBasicAuth(String user, String password);
+
+    /**
+     * Sets the Authorization: Bearer header as documented in RFC6750
+     *
+     * @param token
+     */
+    void setBearerAuth(String token);
 }


### PR DESCRIPTION
Many of us who wish to use an OAuth protected REST endpoint will need to use the Authorization: Bearer <token> header as defined in RFC6750 (Twitter, Google, Facebook, etc all use and recommend this authorization scheme).  This commit makes this much easier to do.
