### PR TITLE
Remove restErrorHandler field in rest service if not necessary

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/RestHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/RestHolder.java
@@ -178,6 +178,7 @@ public class RestHolder extends BaseGeneratedClassHolder {
 		JMethod setErrorHandlerMethod = codeModelHelper.implementMethod(this, methods, "setRestErrorHandler", TypeKind.VOID.toString(), RestErrorHandler.class.getName());
 
 		if (setErrorHandlerMethod != null) {
+			setRestErrorHandlerField();
 			setErrorHandlerMethod.body().assign(_this().ref(getRestErrorHandlerField()), setErrorHandlerMethod.params().get(0));
 		}
 	}
@@ -256,9 +257,7 @@ public class RestHolder extends BaseGeneratedClassHolder {
 	}
 
 	public JFieldVar getRestErrorHandlerField() {
-		if (restErrorHandlerField == null) {
-			setRestErrorHandlerField();
-		}
+		// restErrorHandlerField is created only if the method setRestErrorHandler is implemented
 		return restErrorHandlerField;
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/HttpMethodsService.java
+++ b/AndroidAnnotations/functional-test-1-5/src/main/java/org/androidannotations/test15/rest/HttpMethodsService.java
@@ -24,6 +24,8 @@ import org.androidannotations.annotations.rest.Options;
 import org.androidannotations.annotations.rest.Post;
 import org.androidannotations.annotations.rest.Put;
 import org.androidannotations.annotations.rest.Rest;
+import org.androidannotations.api.rest.RestClientErrorHandling;
+import org.androidannotations.api.rest.RestErrorHandler;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
@@ -31,7 +33,7 @@ import org.springframework.web.client.RestTemplate;
 
 // if defined, the rootUrl will be added as a prefix to every request
 @Rest(rootUrl = "http://company.com/ajax/services", converters = { MappingJacksonHttpMessageConverter.class }, interceptors = { RequestInterceptor.class })
-public interface HttpMethodsService {
+public interface HttpMethodsService extends RestClientErrorHandling {
 
 	@Delete("/delete/")
 	void delete();


### PR DESCRIPTION
If the interface annotated with `@Rest` doesn't extends `RestClientErrorHandling`, the field `restErrorHandler` won't be assigned and will be always null. So, we shouldn't create it in the generated class and we should remove all the `try-catch`.
That's what does this PR.
