### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 ************************************
 This project is available under the following license:
 ************************************
-Copyright 2012 eBusiness Information
+Copyright 2012-2014 eBusiness Information
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
