### PR TITLE
Update Guava to 15.0

### DIFF
--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -168,7 +168,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>13.0.1</version>
+				<version>15.0</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Needed change to integrate with `parceler`. See the conversation in #977 and the commit message for more details.
