### PR TITLE
Don't log 'Resolve log file' if log level is higher

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/LoggerContext.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/LoggerContext.java
@@ -15,19 +15,18 @@
  */
 package org.androidannotations.logger;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
-
 import org.androidannotations.helper.OptionsHelper;
 import org.androidannotations.logger.appender.Appender;
 import org.androidannotations.logger.appender.ConsoleAppender;
 import org.androidannotations.logger.appender.FileAppender;
 import org.androidannotations.logger.appender.MessagerAppender;
 import org.androidannotations.logger.formatter.Formatter;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LoggerContext {
 
@@ -70,14 +69,14 @@ public class LoggerContext {
 	}
 
 	public void setProcessingEnv(ProcessingEnvironment processingEnv) {
+		OptionsHelper optionsHelper = new OptionsHelper(processingEnv);
+		resolveLogLevel(optionsHelper);
+		addConsoleAppender(optionsHelper);
+
 		for (Appender appender : appenders) {
 			appender.setProcessingEnv(processingEnv);
 			appender.open();
 		}
-
-		OptionsHelper optionsHelper = new OptionsHelper(processingEnv);
-		resolveLogLevel(optionsHelper);
-		addConsoleAppender(optionsHelper);
 	}
 
 	public void close() {

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/appender/FileAppender.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/appender/FileAppender.java
@@ -15,20 +15,20 @@
  */
 package org.androidannotations.logger.appender;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import org.androidannotations.helper.FileHelper;
+import org.androidannotations.logger.Level;
+import org.androidannotations.logger.LoggerContext;
+import org.androidannotations.logger.formatter.FormatterFull;
 
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic.Kind;
-
-import org.androidannotations.helper.FileHelper;
-import org.androidannotations.logger.Level;
-import org.androidannotations.logger.formatter.FormatterFull;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 public class FileAppender extends Appender {
 
@@ -91,10 +91,13 @@ public class FileAppender extends Appender {
 			file = resolveLogFileInParentsDirectories();
 		}
 
+		Level logLevel = LoggerContext.getInstance().getCurrentLevel();
 		Messager messager = processingEnv.getMessager();
 		if (file == null) {
-			messager.printMessage(Kind.WARNING, "Can't resolve log file");
-		} else {
+			if (Level.WARN.isGreaterOrEquals(logLevel)) {
+				messager.printMessage(Kind.WARNING, "Can't resolve log file");
+			}
+		} else if (Level.INFO.isGreaterOrEquals(logLevel)) {
 			messager.printMessage(Kind.NOTE, "Resolve log file to " + file.getAbsolutePath());
 		}
 	}


### PR DESCRIPTION
This PR is a small fix for logging.
The message `Resolve log file to ...` is always logged even if the log level is set to `warn`.
Also, the log level should be resolved before adding appenders.
