### PR TITLE
972 AA cannot be built by latest maven versions

### DIFF
--- a/AndroidAnnotations/functional-test-1-5/pom.xml
+++ b/AndroidAnnotations/functional-test-1-5/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 				<artifactId>android-maven-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.8.2</version>
 				<configuration>
 					<sdk>
 						<platform>14</platform>


### PR DESCRIPTION
Updating the android_maven_plugin to the latest version seems to do the trick
