### PR TITLE
Ignore consume-aar with m2e

### DIFF
--- a/AndroidAnnotations/functional-test-1-5/pom.xml
+++ b/AndroidAnnotations/functional-test-1-5/pom.xml
@@ -132,6 +132,41 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											com.jayway.maven.plugins.android.generation2
+										</groupId>
+										<artifactId>
+											android-maven-plugin
+										</artifactId>
+										<versionRange>
+											[3.8.2,)
+										</versionRange>
+										<goals>
+											<goal>consume-aar</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 </project>


### PR DESCRIPTION
Unfortunately the consume-aar goal of the maven-android-plugin is not supported by m2e-android. Since every goal have to be mapped to eclipse plugins, the functional test project cannot be built with eclipse. This commit addresses this issue by simply ignoring the goal since that does
not affect our project.
