### PR TITLE
Extend RestErrorHandler to catch NestedRuntimeException

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/rest/RestErrorHandler.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/rest/RestErrorHandler.java
@@ -15,7 +15,7 @@
  */
 package org.androidannotations.api.rest;
 
-import org.springframework.web.client.RestClientException;
+import org.springframework.core.NestedRuntimeException;
 
 /**
  * This interface is used for handling rest client exceptions.
@@ -26,5 +26,5 @@ public interface RestErrorHandler {
 	 * 
 	 * @param e
 	 */
-	void onRestClientExceptionThrown(RestClientException e);
+	void onRestClientExceptionThrown(NestedRuntimeException e);
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestMethodHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/rest/RestMethodHandler.java
@@ -230,7 +230,7 @@ public abstract class RestMethodHandler extends BaseAnnotationHandler<RestHolder
 			JTryBlock tryBlock = newBlock._try();
 			codeModelHelper.copy(block, tryBlock.body());
 
-			JCatchBlock jCatch = tryBlock._catch(classes().REST_CLIENT_EXCEPTION);
+			JCatchBlock jCatch = tryBlock._catch(classes().NESTED_RUNTIME_EXCEPTION);
 
 			JBlock catchBlock = jCatch.body();
 			JConditional conditional = catchBlock._if(JOp.ne(holder.getRestErrorHandlerField(), JExpr._null()));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -137,6 +137,7 @@ public final class CanonicalNameConstants {
 	public static final String HTTP_AUTHENTICATION = "org.springframework.http.HttpAuthentication";
 	public static final String HTTP_BASIC_AUTHENTICATION = "org.springframework.http.HttpBasicAuthentication";
 	public static final String REST_CLIENT_EXCEPTION = "org.springframework.web.client.RestClientException";
+	public static final String NESTED_RUNTIME_EXCEPTION = "org.springframework.core.NestedRuntimeException";
 
 	/*
 	 * RoboGuice

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
@@ -177,6 +177,7 @@ public class ProcessHolder {
 		public final JClass HTTP_AUTHENTICATION = refClass(CanonicalNameConstants.HTTP_AUTHENTICATION);
 		public final JClass HTTP_BASIC_AUTHENTICATION = refClass(CanonicalNameConstants.HTTP_BASIC_AUTHENTICATION);
 		public final JClass REST_CLIENT_EXCEPTION = refClass(CanonicalNameConstants.REST_CLIENT_EXCEPTION);
+		public final JClass NESTED_RUNTIME_EXCEPTION = refClass(CanonicalNameConstants.NESTED_RUNTIME_EXCEPTION);
 	}
 
 	private final Map<Element, GeneratedClassHolder> generatedClassHolders = new HashMap<Element, GeneratedClassHolder>();


### PR DESCRIPTION
see issue #1002 - `RestErrorHandler` should not be limited to `RestClientException`. When there is a network problem (`SocketTimeoutException`, `HttpHostConnectException` or an exception thrown by Jackson) Spring's RestTemplate automatically throws a `ResourceAccessException`. We should be able to handle those exceptions as well. 
`ResourceAccessException` and `RestClientException` are both subclasses of `NestedRuntimeException`.

I have not changed the method name `onRestClientExceptionThrown` in order to ensure backwards compatibility. Current users implementing `RestErrorHandler` should not face any problems, even when catching the exceptions manually prior to handling them, since they are all subclasses of `NestedRuntimeException`. 
