### PR TITLE
1010 

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -183,7 +183,6 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	public JFieldVar getContentView() {
 		if (contentView == null) {
 			setContentView();
-			setOnCreateView();
 		}
 		return contentView;
 	}
@@ -210,8 +209,6 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		JVar savedInstanceState = onCreateView.param(classes().BUNDLE, "savedInstanceState");
 
 		JBlock body = onCreateView.body();
-		body.assign(contentView, _super().invoke(onCreateView).arg(inflater).arg(container).arg(savedInstanceState));
-
 		setContentViewBlock = body.block();
 
 		body._return(contentView);


### PR DESCRIPTION
Pull request to fix https://github.com/excilys/androidannotations/issues/1010

The super call has been removed entirely because looking at the Fragment code, in the base case where you extend just Fragment, the super method does not doing anything useful.  

Only in classes like ListFragment does the super do something, namely inflate a default view which is what we want to avoid doing.  The setOnCreateView() method is only called if a custom layout ID has been set on the @EFragment annotation

The setOnCreateView() call from getContentView() has been removed as it causes onCreateView to be overridden even if no custom layout ID has been set which would stop the default layout being inflated.
