### PR TITLE
Expose bundle args of FragmentBuilder

### DIFF
--- a/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/builder/FragmentBuilder.java
+++ b/AndroidAnnotations/androidannotations-api/src/main/java/org/androidannotations/api/builder/FragmentBuilder.java
@@ -170,4 +170,8 @@ public class FragmentBuilder<I extends FragmentBuilder<I>> extends Builder {
 		args.putBundle(key, value);
 		return (I) this;
 	}
+
+	public Bundle args() {
+		return args;
+	}
 }


### PR DESCRIPTION
Implements #1016.
Enable to get arguments bundle from `FragmentBuilder`.
