### PR TITLE
Also register port 80 for plain HTTP

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/HttpsClientHandler.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/handler/HttpsClientHandler.java
@@ -175,6 +175,7 @@ public class HttpsClientHandler extends BaseAnnotationHandler<EComponentHolder> 
 			JVar jVarSchemeReg = jTryBlock.body().decl(classes.SCHEME_REGISTRY, "registry");
 			jVarSchemeReg.init(_new(classes.SCHEME_REGISTRY));
 			jTryBlock.body().add(invoke(jVarSchemeReg, "register").arg(_new(classes.SCHEME).arg("https").arg(jVarSslFact).arg(lit(443))));
+			jTryBlock.body().add(invoke(jVarSchemeReg, "register").arg(_new(classes.SCHEME).arg("http").arg(classes.PLAIN_SOCKET_FACTORY.staticInvoke("getSocketFactory")).arg(lit(80))));
 
 			JVar jVarCcm = jTryBlock.body().decl(classes.CLIENT_CONNECTION_MANAGER, "ccm");
 			jVarCcm.init(_new(classes.SINGLE_CLIENT_CONN_MANAGER).arg(invoke("getParams")).arg(jVarSchemeReg));

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -179,6 +179,7 @@ public final class CanonicalNameConstants {
 	public static final String CLIENT_CONNECTION_MANAGER = "org.apache.http.conn.ClientConnectionManager";
 	public static final String DEFAULT_HTTP_CLIENT = "org.apache.http.impl.client.DefaultHttpClient";
 	public static final String SSL_SOCKET_FACTORY = "org.apache.http.conn.ssl.SSLSocketFactory";
+	public static final String PLAIN_SOCKET_FACTORY = "org.apache.http.conn.scheme.PlainSocketFactory";
 	public static final String SCHEME = "org.apache.http.conn.scheme.Scheme";
 	public static final String SCHEME_REGISTRY = "org.apache.http.conn.scheme.SchemeRegistry";
 	public static final String SINGLE_CLIENT_CONN_MANAGER = "org.apache.http.impl.conn.SingleClientConnManager";

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/process/ProcessHolder.java
@@ -162,6 +162,7 @@ public class ProcessHolder {
 		public final JClass CLIENT_CONNECTION_MANAGER = refClass(CanonicalNameConstants.CLIENT_CONNECTION_MANAGER);
 		public final JClass DEFAULT_HTTP_CLIENT = refClass(CanonicalNameConstants.DEFAULT_HTTP_CLIENT);
 		public final JClass SSL_SOCKET_FACTORY = refClass(CanonicalNameConstants.SSL_SOCKET_FACTORY);
+		public final JClass PLAIN_SOCKET_FACTORY = refClass(CanonicalNameConstants.PLAIN_SOCKET_FACTORY);
 		public final JClass SCHEME = refClass(CanonicalNameConstants.SCHEME);
 		public final JClass SCHEME_REGISTRY = refClass(CanonicalNameConstants.SCHEME_REGISTRY);
 		public final JClass SINGLE_CLIENT_CONN_MANAGER = refClass(CanonicalNameConstants.SINGLE_CLIENT_CONN_MANAGER);


### PR DESCRIPTION
Also register port 80 for plain HTTP in order to support apps that go through a plain HTTP proxy.

Right now, if you use `@HttpsClient` and connect to a HTTPS server _through_ a plain HTTP proxy, you'll get 

> java.lang.IllegalStateException: Scheme 'http' not registered
