### PR TITLE
fix issue issues with generic @EView and @EViewGroup

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
@@ -216,6 +216,13 @@ public class APTCodeModelHelper {
 		return method;
 	}
 
+	public void generifyStaticHelper(GeneratedClassHolder holder, JMethod staticHelper, TypeElement annotatedClass) {
+		for (TypeParameterElement param : annotatedClass.getTypeParameters()) {
+			JClass bounds = typeBoundsToJClass(holder, param.getBounds());
+			staticHelper.generify(param.getSimpleName().toString(), bounds);
+		}
+	}
+
 	private JMethod findAlreadyGeneratedMethod(ExecutableElement executableElement, GeneratedClassHolder holder) {
 		JDefinedClass definedClass = holder.getGeneratedClass();
 		String methodName = executableElement.getSimpleName().toString();
@@ -497,5 +504,4 @@ public class APTCodeModelHelper {
 			return lit((String) o);
 		}
 	}
-
 }

--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
@@ -71,14 +71,17 @@ public class EViewHolder extends EComponentWithViewSupportHolder {
 		for (ExecutableElement userConstructor : constructors) {
 			JMethod copyConstructor = generatedClass.constructor(PUBLIC);
 			JMethod staticHelper = generatedClass.method(PUBLIC | STATIC, generatedClass._extends(), "build");
+
+			codeModelHelper.generifyStaticHelper(this, staticHelper, getAnnotatedElement());
+
 			JBlock body = copyConstructor.body();
 			JInvocation superCall = body.invoke("super");
 			JInvocation newInvocation = JExpr._new(generatedClass);
 			for (VariableElement param : userConstructor.getParameters()) {
 				String paramName = param.getSimpleName().toString();
-				String paramType = param.asType().toString();
-				copyConstructor.param(refClass(paramType), paramName);
-				staticHelper.param(refClass(paramType), paramName);
+				JClass paramType = codeModelHelper.typeMirrorToJClass(param.asType(), this);
+				copyConstructor.param(paramType, paramName);
+				staticHelper.param(paramType, paramName);
 				superCall.arg(JExpr.ref(paramName));
 				newInvocation.arg(JExpr.ref(paramName));
 			}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/EViewGroupTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/EViewGroupTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2010-2014 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.eviewgroup;
+
+import org.androidannotations.AndroidAnnotationProcessor;
+import org.androidannotations.utils.AAProcessorTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EViewGroupTest extends AAProcessorTestHelper {
+	@Before
+	public void setup() {
+		addManifestProcessorParameter(EViewGroupTest.class);
+		addProcessor(AndroidAnnotationProcessor.class);
+	}
+
+	@Test
+	public void view_group_with_generic_compiles() {
+		assertCompilationSuccessful(compileFiles(
+				SomeGenericViewGroup.class,
+				SomeGenericViewGroupExt.class));
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/SomeGenericViewGroup.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/SomeGenericViewGroup.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2010-2014 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.eviewgroup;
+
+import android.content.Context;
+import android.widget.FrameLayout;
+import org.androidannotations.annotations.EViewGroup;
+import org.androidannotations.annotations.UiThread;
+
+@EViewGroup
+public class SomeGenericViewGroup<T extends CharSequence> extends FrameLayout {
+
+	interface Test<T> {
+		void test(T t);
+	}
+
+	private T object;
+	private Test<T> testInterface;
+
+	public SomeGenericViewGroup(Context context) {
+		super(context);
+	}
+
+	public SomeGenericViewGroup(Context context, T object, Test<T> testInterface) {
+		super(context);
+		this.object = object;
+		this.testInterface = testInterface;
+	}
+
+	@UiThread
+	void someGenericMethod(T type) {
+	}
+
+	@UiThread
+	void someGenericMethod2(T type) {
+	}
+
+}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/SomeGenericViewGroupExt.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/SomeGenericViewGroupExt.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2010-2014 eBusiness Information, Excilys Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.eviewgroup;
+
+import android.content.Context;
+import org.androidannotations.annotations.EViewGroup;
+import org.androidannotations.annotations.UiThread;
+
+@EViewGroup
+public class SomeGenericViewGroupExt extends SomeGenericViewGroup<String> {
+
+	public SomeGenericViewGroupExt(Context context) {
+		super(context);
+	}
+
+	public SomeGenericViewGroupExt(Context context, String object, Test<String> testInterface) {
+		super(context, object, testInterface);
+	}
+
+	@Override
+	@UiThread
+	void someGenericMethod(String type) {
+	}
+}

--- a/AndroidAnnotations/androidannotations/src/test/resources/org/androidannotations/eviewgroup/AndroidManifest.xml
+++ b/AndroidAnnotations/androidannotations/src/test/resources/org/androidannotations/eviewgroup/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (C) 2010-2014 eBusiness Information, Excilys Group
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed To in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="org.androidannotations.testprocessor"
+          android:versionCode="1"
+          android:versionName="1.0">
+
+</manifest>


### PR DESCRIPTION
There are still some issues with generics corner cases like A super B, or A extends B&C. If issues like A extends B&C just time consuming, in case of A super B it looks like there is no way to handle it. This is because JMethod's generify creates JTypeVar, that final and always produces bounds with "extends" keyword. But if something comes to your minds, guys, please, share your ideas :)
