### PR TITLE
Silence the JavacFiler warning 'compiler.warn.proc.unclosed.type.files'

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/FileHelper.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/helper/FileHelper.java
@@ -22,7 +22,8 @@ import java.net.URISyntaxException;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.tools.JavaFileObject;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 
 public class FileHelper {
 
@@ -45,9 +46,9 @@ public class FileHelper {
 	public static Option<FileHolder> findRootProjectHolder(ProcessingEnvironment processingEnv) {
 		Filer filer = processingEnv.getFiler();
 
-		JavaFileObject dummySourceFile;
+		FileObject dummySourceFile;
 		try {
-			dummySourceFile = filer.createSourceFile("dummy" + System.currentTimeMillis());
+			dummySourceFile = filer.createResource(StandardLocation.SOURCE_OUTPUT, "", "dummy" + System.currentTimeMillis());
 		} catch (IOException ignored) {
 			return Option.absent();
 		}


### PR DESCRIPTION
This prevents warnings like:

   warning: Unclosed files for the types '[dummy1407426008266]'; these types will not undergo annotation processing

originating from com.sun.tools.javac.processing.JavacFiler.warnIfUnclosedFiles.

It works by opening and closing an OutputStream on the dummy JavaFileObject,
thereby clearing the dummy filename from the JavacFilers internal openTypeNames set.

Note, this will result in a an empty dummy file, e.g.  build/generated/source/apt/debug/dummy1407426008266.java
