### PR TITLE
Specify android build-tools in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 android:
   components:
     - android-14
+    - build-tools-20.0.0
   licenses:
     - android-sdk-license-5be876d5
 script:


### PR DESCRIPTION
From July 2014 it is necessary to specify which build-tools version should
be used when building an Android project with Travis CI.

http://docs.travis-ci.com/user/languages/android/
