### PR TITLE
Fix androidannotations.log in apt folder

### DIFF
--- a/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/appender/FileAppender.java
+++ b/AndroidAnnotations/androidannotations/src/main/java/org/androidannotations/logger/appender/FileAppender.java
@@ -80,7 +80,9 @@ public class FileAppender extends Appender {
 	@Override
 	public void setProcessingEnv(ProcessingEnvironment processingEnv) {
 		super.setProcessingEnv(processingEnv);
-		resolveLogFile();
+		if (file == null) {
+			resolveLogFile();
+		}
 	}
 
 	private void resolveLogFile() {


### PR DESCRIPTION
A quick fix for [the issue](https://github.com/excilys/androidannotations/pull/1110#issuecomment-67879129) raised by @WonderCsabo.
