### PR TITLE
Include test sources in Checkstyle audit

### DIFF
--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/copyannotations/CopyOtherAnnotationsTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/copyannotations/CopyOtherAnnotationsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class CopyOtherAnnotationsTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(CopyOtherAnnotationsTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
@@ -35,20 +35,23 @@ public class CopyOtherAnnotationsTest extends AAProcessorTestHelper {
 
 	@Test
 	public void testGeneratedClassHasCopiedNonAAAnnotations() {
+		// CHECKSTYLE:OFF
 		String[] classHeader = { //
 				"@XmlType", //
 				"@TestTargetClass(String.class)", //
 				"@WebServiceRefs({", //
 				"    @WebServiceRef(type = String.class)", //
 				"})", //
-				"public final class HasOtherAnnotations_" };
-
+				"public final class HasOtherAnnotations_", };
+		
+		// CHECKSTYLE:ON
 		compileFiles(HasOtherAnnotations.class);
 		assertGeneratedClassContains(toGeneratedFile(HasOtherAnnotations.class), classHeader);
 	}
 
 	@Test
 	public void testOverridenMethodHasCopiedNonAAAnnotations() {
+		// CHECKSTYLE:OFF
 		String[] methodSignature = { //
 				"    @Addressing(responses = (javax.xml.ws.soap.AddressingFeature.Responses.ALL))", //
 				"    @Action(input = \"someString\")", //
@@ -57,8 +60,9 @@ public class CopyOtherAnnotationsTest extends AAProcessorTestHelper {
 				"        \"hi\"", //
 				"    })", //
 				"    @Override", //
-				"    public void onEvent(final Event event) {" };
-
+				"    public void onEvent(final Event event) {", };
+		// CHECKSTYLE:ON
+		
 		compileFiles(HasOtherAnnotations.class);
 		assertGeneratedClassContains(toGeneratedFile(HasOtherAnnotations.class), methodSignature);
 	}
@@ -67,21 +71,23 @@ public class CopyOtherAnnotationsTest extends AAProcessorTestHelper {
 	public void testOverrideDoesNotAddedTwice() {
 		addProcessorParameter("trace", "true");
 		compileFiles(HasOtherAnnotations.class);
-
+		
+		// CHECKSTYLE:OFF
 		String[] methodSignature = { //
 				"    @java.lang.Override", //
 				"    @java.lang.Override", //
-				"    public String toString() {" };
-
+				"    public String toString() {", };
+		// CHECKSTYLE:ON
+		
 		assertGeneratedClassDoesNotContain(toGeneratedFile(HasOtherAnnotations.class), methodSignature);
 	}
-	
+
 	@Test
 	public void testInheritedAnnotationsNotCopied() {
 		compileFiles(HasOtherAnnotations.class);
-		
-		String[] annotation = { "@RunWith(Runner.class)" };
-		
+
+		String[] annotation = { "@RunWith(Runner.class)", };
+
 		assertGeneratedClassDoesNotContain(toGeneratedFile(HasOtherAnnotations.class), annotation);
 	}
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/EBeanTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/EBeanTest.java
@@ -23,18 +23,18 @@ import org.junit.Test;
 public class EBeanTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(EBeanTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void activity_subclass_in_manifest_compiles() {
-        assertCompilationSuccessful(compileFiles(
-                SomeActivity.class,
-                SomeImplementation.class,
-                SomeGenericBean.class,
-                SomeGenericBeanExt.class));
-    }
+	public void activitySubclassInManifestCompiles() {
+		assertCompilationSuccessful(compileFiles(
+				SomeActivity.class,
+				SomeImplementation.class,
+				SomeGenericBean.class,
+				SomeGenericBeanExt.class));
+	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/SomeActivity.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/SomeActivity.java
@@ -28,7 +28,7 @@ public class SomeActivity extends Activity {
 	@Bean(SomeImplementation.class)
 	SomeInterface someInterface;
 
-    @Bean
-    SomeGenericBean<Object> objectSomeGenericBean;
+	@Bean
+	SomeGenericBean<Object> objectSomeGenericBean;
 
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/SomeGenericBean.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/ebean/SomeGenericBean.java
@@ -24,20 +24,19 @@ import org.androidannotations.annotations.UiThread;
 @EBean
 public class SomeGenericBean<T> {
 
-    @Background
-	void someMethod(List<? super T> list){
+	@Background
+	void someMethod(List<? super T> list) {
 	}
 
-    void someOtherMethod(List<? super T> list){
-    }
+	void someOtherMethod(List<? super T> list) {
+	}
 
-    @Background
-    <N extends T> void someParameterizedMethod(List<? super N> lst, List<? extends N> lst2) {
-    }
+	@Background
+	<N extends T> void someParameterizedMethod(List<? super N> lst, List<? extends N> lst2) {
+	}
 
-    @UiThread
-    <T, S extends Number> void emptyUiMethod(List<? extends T> param, List<? super S> param2) {
-    }
-
+	@UiThread
+	<T, S extends Number> void emptyUiMethod(List<? extends T> param, List<? super S> param2) {
+	}
 
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/EViewGroupTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/eviewgroup/EViewGroupTest.java
@@ -22,13 +22,13 @@ import org.junit.Test;
 
 public class EViewGroupTest extends AAProcessorTestHelper {
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(EViewGroupTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void view_group_with_generic_compiles() {
+	public void viewGroupWithGenericCompiles() {
 		assertCompilationSuccessful(compileFiles(
 				SomeGenericViewGroup.class,
 				SomeGenericViewGroupExt.class));

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/ActivityIntentFragmentTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/ActivityIntentFragmentTest.java
@@ -29,12 +29,12 @@ public class ActivityIntentFragmentTest extends AAProcessorTestHelper {
 	private static final String INTENT_FRAGMENT_SUPPORT_SIGNATURE = ".*public static ActivityInManifest_\\.IntentBuilder_ intent\\((android\\.support\\.v4\\.app\\.)?Fragment supportFragment\\).*";
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void activity_intentFragment_minSdkFroyo_compileWithFroyo() {
+	public void activityIntentFragmentMinSdkFroyoCompilesWithFroyo() {
 		addManifestProcessorParameter(ActivityIntentFragmentTest.class, "AndroidManifestMinFroyo.xml");
 		CompileResult result = compileFiles(ActivityInManifest.class);
 		File generatedFile = toGeneratedFile(ActivityInManifest.class);
@@ -44,7 +44,7 @@ public class ActivityIntentFragmentTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void activity_intentFragment_minSdkFroyo_compileWithJB() {
+	public void activityIntentFragmentMinSdkFroyoCompilesWithJB() {
 		// To simulate compilation with SDK > 11, we add Fragment in classpath
 		addManifestProcessorParameter(ActivityIntentFragmentTest.class, "AndroidManifestMinFroyo.xml");
 		CompileResult result = compileFiles(toPath(ActivityIntentFragmentTest.class, "Fragment.java"), ActivityInManifest.class);
@@ -55,7 +55,7 @@ public class ActivityIntentFragmentTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void activity_intentFragment_minSdkJB_compileWithJB() {
+	public void activityIntentFragmentMinSdkJBCompileWithJB() {
 		// To simulate compilation with SDK > 11, we add Fragment in classpath
 		addManifestProcessorParameter(ActivityIntentFragmentTest.class, "AndroidManifestMinJB.xml");
 		CompileResult result = compileFiles(toPath(ActivityIntentFragmentTest.class, "Fragment.java"), ActivityInManifest.class);
@@ -66,7 +66,7 @@ public class ActivityIntentFragmentTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void activity_intentFragment_compileWithSupport() {
+	public void activityIntentFragmentCompilesWithSupport() {
 		// To simulate android support v4 in classpath, we add
 		// android.support.v4.Fragment in classpath
 		addManifestProcessorParameter(ActivityIntentFragmentTest.class, "AndroidManifestMinFroyo.xml");
@@ -78,7 +78,7 @@ public class ActivityIntentFragmentTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void activity_intentFragment_minSdkJB_compileWithJBAndSupport() {
+	public void activityIntentFragmentMinSdkJBCompilesWithJBAndSupport() {
 		// To simulate compilation with SDK > 11, we add Fragment in classpath
 		addManifestProcessorParameter(ActivityIntentFragmentTest.class, "AndroidManifestMinJB.xml");
 		CompileResult result = compileFiles(toPath(ActivityIntentFragmentTest.class, "Fragment.java"), toPath(ActivityIntentFragmentTest.class, "support/Fragment.java"), ActivityInManifest.class);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/OnBackPressedApiDependenciesTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/OnBackPressedApiDependenciesTest.java
@@ -25,20 +25,20 @@ import org.junit.Test;
 public class OnBackPressedApiDependenciesTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(OnBackPressedApiDependenciesTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 		ensureOutputDirectoryIsEmpty();
 	}
 
 	@Test
-	public void activity_with_on_back_pressed_generate_api_dependency() throws IOException {
+	public void activityWithOnBackPressedGeneratesApiDependency() throws IOException {
 		CompileResult result = compileFiles(ActivityWithOnBackPressedMethod.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void activity_without_on_back_pressed_do_not_generate_api_dependency() throws IOException {
+	public void activityWithoutOnBackPressedDoesNotGenerateApiDependency() throws IOException {
 		CompileResult result = compileFiles(ActivityWithBackgroundMethod.class);
 		assertCompilationSuccessful(result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/OnBackgroundApiDependenciesTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/OnBackgroundApiDependenciesTest.java
@@ -25,20 +25,20 @@ import org.junit.Test;
 public class OnBackgroundApiDependenciesTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(OnBackgroundApiDependenciesTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 		ensureOutputDirectoryIsEmpty();
 	}
 
 	@Test
-	public void activity_with_background_annotated_method_generate_api_dependency() throws IOException {
+	public void activityWithBackgroundAnnotatedMethodGenerateApiDependency() throws IOException {
 		CompileResult result = compileFiles(ActivityWithBackgroundMethod.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void activity_without_background_annotated_method_generate_api_dependency() throws IOException {
+	public void activityWithoutBackgroundAnnotatedMethodGenerateApiDependency() throws IOException {
 		CompileResult result = compileFiles(ActivityWithOnBackPressedMethod.class);
 		assertCompilationSuccessful(result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/SharedPrefsApiDependenciesTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/generation/SharedPrefsApiDependenciesTest.java
@@ -42,34 +42,34 @@ import org.junit.Test;
 
 public class SharedPrefsApiDependenciesTest extends AAProcessorTestHelper {
 
-	private static final Class<?>[] SHARED_PREF_API_DEPENDENCIES = new Class<?>[] { AbstractPrefEditorField.class,//
-			AbstractPrefField.class,//
-			BooleanPrefEditorField.class,//
-			BooleanPrefField.class,//
-			EditorHelper.class,//
-			FloatPrefEditorField.class,//
-			FloatPrefField.class,//
-			IntPrefEditorField.class,//
-			IntPrefField.class,//
-			LongPrefEditorField.class,//
-			LongPrefField.class,//
-			SharedPreferencesCompat.class,//
-			SharedPreferencesHelper.class,//
-			StringPrefEditorField.class,//
-			StringPrefField.class, //
-			StringSetPrefEditorField.class,//
-			StringSetPrefField.class //
+	private static final Class<?>[] SHARED_PREF_API_DEPENDENCIES = new Class<?>[] { AbstractPrefEditorField.class, //
+		AbstractPrefField.class, //
+		BooleanPrefEditorField.class, //
+		BooleanPrefField.class, //
+		EditorHelper.class, //
+		FloatPrefEditorField.class, //
+		FloatPrefField.class, //
+		IntPrefEditorField.class, //
+		IntPrefField.class, //
+		LongPrefEditorField.class, //
+		LongPrefField.class, //
+		SharedPreferencesCompat.class, //
+		SharedPreferencesHelper.class, //
+		StringPrefEditorField.class, //
+		StringPrefField.class, //
+		StringSetPrefEditorField.class, //
+		StringSetPrefField.class, //
 	};
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(SharedPrefsApiDependenciesTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 		ensureOutputDirectoryIsEmpty();
 	}
 
 	@Test
-	public void class_with_prefs_do_not_generate_api_dependencies() throws IOException {
+	public void classWithPrefsDoesNotGenerateApiDependencies() throws IOException {
 		compileFiles(SharedPrefs.class);
 		for (Class<?> apiDependency : SHARED_PREF_API_DEPENDENCIES) {
 			assertClassSourcesNotGeneratedToOutput(apiDependency);
@@ -77,7 +77,7 @@ public class SharedPrefsApiDependenciesTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void class_without_prefs_do_not_generate_api_dependencies() throws IOException {
+	public void classWithoutPrefsDoesNotGenerateApiDependencies() throws IOException {
 		compileFiles(SomeClass.class);
 		for (Class<?> apiDependency : SHARED_PREF_API_DEPENDENCIES) {
 			assertClassSourcesNotGeneratedToOutput(apiDependency);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/hierarchyviewer/HierarchyViewerActivityTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/hierarchyviewer/HierarchyViewerActivityTest.java
@@ -25,27 +25,27 @@ import org.junit.Test;
 public class HierarchyViewerActivityTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(HierarchyViewerActivityTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void hierarchy_viewer_activity_compiles() {
+	public void hierarchyViewerActivityCompiles() {
 		addManifestProcessorParameter(HierarchyViewerActivityTest.class, "AndroidManifest.xml");
 		CompileResult result = compileFiles(HierarchyViewerActivity.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void hierarchy_viewer_activity_with_no_debbugable_does_not_compile() throws IOException {
+	public void hierarchyViewerActivityWithNoDebbugableDoesNotCompile() throws IOException {
 		addManifestProcessorParameter(HierarchyViewerActivityTest.class, "NoDebbugableManifest.xml");
 		CompileResult result = compileFiles(HierarchyViewerActivity.class);
 		assertCompilationErrorOn(HierarchyViewerActivity.class, "@HierarchyViewerSupport", result);
 	}
 
 	@Test
-	public void hierarchy_viewer_activity_with_no_internet_permission_does_not_compile() throws IOException {
+	public void hierarchyViewerActivityWithNoInternetPermissionDoesNotCompile() throws IOException {
 		addManifestProcessorParameter(HierarchyViewerActivityTest.class, "NoInternetPermissionManifest.xml");
 		CompileResult result = compileFiles(HierarchyViewerActivity.class);
 		assertCompilationErrorOn(HierarchyViewerActivity.class, "@HierarchyViewerSupport", result);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/logger/formatter/FormatterTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/logger/formatter/FormatterTest.java
@@ -39,7 +39,7 @@ public class FormatterTest {
 	}
 
 	@Test
-	public void testBuildFullMessage_string() throws Exception {
+	public void testBuildFullMessageString() throws Exception {
 		Assert.assertEquals("This is a test", formatter.buildFullMessage("{} is a test", "This"));
 		Assert.assertEquals("This is a test", formatter.buildFullMessage("This is a {}", "test"));
 		Assert.assertEquals("This is a test", formatter.buildFullMessage("This {} {} test", "is", "a"));
@@ -47,19 +47,19 @@ public class FormatterTest {
 	}
 
 	@Test
-	public void testBuildFullMessage_int_array() throws Exception {
+	public void testBuildFullMessageIntArray() throws Exception {
 		Integer[] values = new Integer[] { 1, 2 };
 		Assert.assertEquals("Values = [1, 2]", formatter.buildFullMessage("Values = {}", new Object[] { values }));
 	}
 
 	@Test
-	public void testBuildFullMessage_object_array() throws Exception {
+	public void testBuildFullMessageObjectArray() throws Exception {
 		SomeObject[] values = new SomeObject[] { new SomeObject("a"), new SomeObject("b") };
 		Assert.assertEquals("Objects = [a, b]", formatter.buildFullMessage("Objects = {}", new Object[] { values }));
 	}
 
 	@Test
-	public void testBuildFullMessage_list() throws Exception {
+	public void testBuildFullMessageList() throws Exception {
 		List<SomeObject> values = Arrays.asList(new SomeObject("a"), new SomeObject("b"));
 		Assert.assertEquals("Objects = [a, b]", formatter.buildFullMessage("Objects = {}", values));
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/manifest/AndroidManifestErrorsTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/manifest/AndroidManifestErrorsTest.java
@@ -25,25 +25,25 @@ import org.junit.Test;
 public class AndroidManifestErrorsTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(AndroidManifestErrorsTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void activity_subclass_in_manifest_compiles() {
+	public void activitySubclassInManifestCompiles() {
 		CompileResult result = compileFiles(ActivitySubclassInManifest.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void activity_in_manifest_does_not_compile() throws IOException {
+	public void activityInManifestDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ActivityInManifest.class);
 		assertCompilationErrorOn(ActivityInManifest.class, "@EActivity", result);
 	}
 
 	@Test
-	public void activity_not_in_manifest_compiles_with_warning() throws IOException {
+	public void activityNotInManifestCompilesWithWarning() throws IOException {
 		CompileResult result = compileFiles(ActivityNotInManifest.class);
 		assertCompilationWarningOn(ActivityNotInManifest.class, "@EActivity", result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/manifest/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/manifest/AndroidManifestFinderTest.java
@@ -31,26 +31,26 @@ import com.google.common.io.ByteStreams;
 public class AndroidManifestFinderTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void fails_if_no_manifest() {
+	public void failsIfNoManifest() {
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationErrorWithNoSource(result);
 		assertCompilationErrorCount(1, result);
 	}
 
 	@Test
-	public void finds_specified_manifest() {
+	public void findsSpecifiedManifest() {
 		addManifestProcessorParameter(AndroidManifestFinderTest.class);
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void fails_if_cannot_find_specified_manifest() {
+	public void failsIfCannotFindSpecifiedManifest() {
 		addProcessorParameter("androidManifestFile", "/some/random/path/AndroidManifest.xml");
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationErrorWithNoSource(result);
@@ -58,7 +58,7 @@ public class AndroidManifestFinderTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void finds_manifest_in_generated_source_parent_folder() throws Exception {
+	public void findsManifestInGeneratedSourceParentFolder() throws Exception {
 		copyManifestToParentOfOutputDirectory();
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationSuccessful(result);
@@ -66,7 +66,7 @@ public class AndroidManifestFinderTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void fails_if_cannot_parse_manifest() {
+	public void failsIfCannotParseManifest() {
 		addManifestProcessorParameter(AndroidManifestFinderTest.class, "ParseErrorManifest.xml");
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationErrorWithNoSource(result);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/menu/OptionMenuErrorsTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/menu/OptionMenuErrorsTest.java
@@ -25,19 +25,19 @@ import org.junit.Test;
 public class OptionMenuErrorsTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(OptionMenuErrorsTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void android_menuitem_in_sherlock_activity() throws IOException {
+	public void androidMenuitemInSherlockActivity() throws IOException {
 		CompileResult result = compileFiles(SherlockActivityWithAndroidMenu.class);
 		assertCompilationErrorOn(SherlockActivityWithAndroidMenu.class, "@OptionsMenuItem", result);
 	}
 
 	@Test
-	public void sherlock_menuitem_in_android_activity() throws IOException {
+	public void sherlockMenuitemInAndroidActivity() throws IOException {
 		CompileResult result = compileFiles(ActivityWithSherlockMenu.class);
 		assertCompilationErrorOn(ActivityWithSherlockMenu.class, "@OptionsMenuItem", result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rclass/RClassFinderTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rclass/RClassFinderTest.java
@@ -24,13 +24,13 @@ import org.junit.Test;
 public class RClassFinderTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(RClassFinderTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void fails_if_cannot_find_R_class() {
+	public void failsIfCannotFindRClass() {
 		CompileResult result = compileFiles(SomeClass.class);
 		assertCompilationErrorWithNoSource(result);
 		assertCompilationErrorCount(1, result);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/receiver/ReceiverRegistrationTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/receiver/ReceiverRegistrationTest.java
@@ -25,43 +25,43 @@ import org.junit.Test;
 public class ReceiverRegistrationTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(ActivityWithValidReceiver.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void activity_with_valid_receiver_annotation_compile() throws IOException {
+	public void activityWithValidReceiverAnnotationCompiles() throws IOException {
 		CompileResult result = compileFiles(ActivityWithValidReceiver.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void activity_with_invalid_registerAt_not_compile() throws IOException {
+	public void activityWithInvalidRegisterAtDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ActivityWithInvalidRegisterAt.class);
 		assertCompilationErrorOn(ActivityWithInvalidRegisterAt.class, "@Receiver", result);
 	}
 
 	@Test
-	public void activity_with_two_method_with_same_name_not_compile() throws IOException {
+	public void activityWithTwoMethodWithSameNameDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ActivityWithTwoSameNameMethod.class);
 		assertCompilationErrorOn(ActivityWithTwoSameNameMethod.class, "@Receiver", result);
 	}
 
 	@Test
-	public void fragment_with_valid_receiver_annotation_compile() throws IOException {
+	public void fragmentWithValidReceiverAnnotationCompiles() throws IOException {
 		CompileResult result = compileFiles(FragmentWithValidReceiver.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void service_with_valid_receiver_annotation_compile() throws IOException {
+	public void serviceWithValidReceiverAnnotationCompiles() throws IOException {
 		CompileResult result = compileFiles(ServiceWithValidReceiver.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void service_with_invalid_registerAt_not_compile() throws IOException {
+	public void serviceWithInvalidRegisterAtDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ServiceWithInvalidReceiver.class);
 		assertCompilationErrorOn(ServiceWithInvalidReceiver.class, "@Receiver", result);
 		assertCompilationErrorCount(3, result);

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/ClassClient.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/ClassClient.java
@@ -17,7 +17,9 @@ package org.androidannotations.rest;
 
 import org.androidannotations.annotations.rest.Rest;
 
+// CHECKSTYLE:OFF
 @Rest(converters = {})
+// CHECKSTYLE:ON
 public class ClassClient {
 
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/ClientWithNoConverters.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/ClientWithNoConverters.java
@@ -17,7 +17,9 @@ package org.androidannotations.rest;
 
 import org.androidannotations.annotations.rest.Rest;
 
+// CHECKSTYLE:OFF
 @Rest(converters = {})
+// CHECKSTYLE:ON
 public interface ClientWithNoConverters {
 
 }

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestConverterTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestConverterTest.java
@@ -25,37 +25,37 @@ import org.junit.Test;
 public class RestConverterTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(RestConverterTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void client_with_no_converters_compiles() {
+	public void clientWithNoConvertersCompiles() {
 		CompileResult result = compileFiles(ClientWithNoConverters.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void client_with_valid_converter_compiles() {
+	public void clientWithValidConverterCompiles() {
 		CompileResult result = compileFiles(ClientWithValidConverter.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void client_with_abstract_converter_does_not_compile() throws IOException {
+	public void clientWithAbstractConverterDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithAbstractConverter.class);
 		assertCompilationErrorOn(ClientWithAbstractConverter.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_with_non_converter_does_not_compile() throws IOException {
+	public void clientWithNonConverterDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithNonConverter.class);
 		assertCompilationErrorOn(ClientWithNonConverter.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_with_wrong_constructor_converter_does_not_compile() throws IOException {
+	public void clientWithWrongConstructorConverterDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongConstructorConverter.class);
 		assertCompilationErrorOn(ClientWithWrongConstructorConverter.class, "@Rest", result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestInterceptorTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestInterceptorTest.java
@@ -25,31 +25,31 @@ import org.junit.Test;
 public class RestInterceptorTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(RestInterceptorTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void client_with_valid_interceptor_compiles() {
+	public void clientWithValidInterceptorCompiles() {
 		CompileResult result = compileFiles(ClientWithValidInterceptor.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void client_with_abstract_interceptor_does_not_compile() throws IOException {
+	public void clientWithAbstractInterceptorDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithAbstractInterceptor.class);
 		assertCompilationErrorOn(ClientWithAbstractInterceptor.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_with_non_interceptor_does_not_compile() throws IOException {
+	public void clientWithNonInterceptorDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithNonInterceptor.class);
 		assertCompilationErrorOn(ClientWithNonInterceptor.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_with_wrong_constructor_interceptor_does_not_compile() throws IOException {
+	public void clientWithWrongConstructorInterceptorDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongConstructorInterceptor.class);
 		assertCompilationErrorOn(ClientWithWrongConstructorInterceptor.class, "@Rest", result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestTest.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/rest/RestTest.java
@@ -25,26 +25,26 @@ import org.junit.Test;
 public class RestTest extends AAProcessorTestHelper {
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		addManifestProcessorParameter(RestTest.class);
 		addProcessor(AndroidAnnotationProcessor.class);
 	}
 
 	@Test
-	public void class_client_does_not_compile() throws IOException {
+	public void classClientDoesNotCompile() throws IOException {
 		CompileResult result = compileFiles(ClassClient.class);
 		assertCompilationErrorOn(ClassClient.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_no_internet_permission_does_not_compile() throws IOException {
+	public void clientNoInternetPermissionDoesNotCompile() throws IOException {
 		addManifestProcessorParameter(RestTest.class, "NoInternetPermissionManifest.xml");
 		CompileResult result = compileFiles(ClientWithNoConverters.class);
 		assertCompilationErrorOn(ClientWithNoConverters.class, "@Rest", result);
 	}
 
 	@Test
-	public void client_with_return_type() throws IOException {
+	public void clientWithReturnType() throws IOException {
 		CompileResult result = compileFiles(ClientWithResponseEntity.class);
 		assertCompilationErrorOn(ClientWithResponseEntity.class, "@Options", result);
 		assertCompilationErrorOn(ClientWithResponseEntity.class, "@Head", result);
@@ -52,7 +52,7 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void client_with_request_entity() throws IOException {
+	public void clientWithRequestEntity() throws IOException {
 		CompileResult result = compileFiles(ClientWithRequestEntity.class);
 		assertCompilationErrorOn(ClientWithRequestEntity.class, "@Get", result);
 		assertCompilationErrorOn(ClientWithRequestEntity.class, "@Head", result);
@@ -61,7 +61,7 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void client_with_primitive_return_types() throws IOException {
+	public void clientWithPrimitiveReturnTypes() throws IOException {
 		CompileResult result = compileFiles(ClientWithPrimitiveReturnType.class);
 		assertCompilationErrorOn(ClientWithPrimitiveReturnType.class, "@Delete", result);
 		assertCompilationErrorOn(ClientWithPrimitiveReturnType.class, "@Get", result);
@@ -73,13 +73,13 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void client_with_path_variables() throws IOException {
+	public void clientWithPathVariables() throws IOException {
 		CompileResult result = compileFiles(ClientWithPathVariable.class);
 		assertCompilationSuccessful(result);
 	}
 
 	@Test
-	public void client_with_wrong_enhanced_methods() throws IOException {
+	public void clientWithWrongEnhancedMethods() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongEnhancedMethod.class);
 		assertCompilationErrorOn(ClientWithWrongEnhancedMethod.class, "Object getRestTemplate();", result);
 		assertCompilationErrorOn(ClientWithWrongEnhancedMethod.class, "String getURL();", result);
@@ -90,13 +90,13 @@ public class RestTest extends AAProcessorTestHelper {
 	}
 
 	@Test
-	public void client_with_wrong_interface() throws IOException {
+	public void clientWithWrongInterface() throws IOException {
 		CompileResult result = compileFiles(ClientWithWrongInterface.class);
 		assertCompilationErrorCount(1, result);
 	}
 
 	@Test
-	public void client_with_all_interfaces() throws IOException {
+	public void clientWithAllInterfaces() throws IOException {
 		CompileResult result = compileFiles(ClientWithAllInterfaces.class);
 		assertCompilationSuccessful(result);
 	}

--- a/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/ClassFinder.java
+++ b/AndroidAnnotations/androidannotations/src/test/java/org/androidannotations/utils/ClassFinder.java
@@ -15,6 +15,8 @@
  */
 package org.androidannotations.utils;
 
+import static java.util.Collections.synchronizedList;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -30,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
-import java.util.Vector;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -60,7 +61,7 @@ public class ClassFinder {
 	 * @param fqcn
 	 *            Name of superclass/interface on which to search
 	 */
-	public final Vector<Class<?>> findClassesInPackage(String packageName) {
+	public final List<Class<?>> findClassesInPackage(String packageName) {
 		synchronized (classpathLocations) {
 			synchronized (results) {
 				errors = new ArrayList<Throwable>();
@@ -113,11 +114,7 @@ public class ClassFinder {
 	private final static FileFilter DIRECTORIES_ONLY = new FileFilter() {
 		@Override
 		public boolean accept(File f) {
-			if (f.exists() && f.isDirectory()) {
-				return true;
-			} else {
-				return false;
-			}
+			return f.exists() && f.isDirectory();
 		}
 	};
 
@@ -135,7 +132,7 @@ public class ClassFinder {
 		}
 	};
 
-	private final void include(String name, File file, Map<URL, String> map) {
+	private void include(String name, File file, Map<URL, String> map) {
 		if (!file.exists()) {
 			return;
 		}
@@ -229,10 +226,10 @@ public class ClassFinder {
 		return s.replace('/', '.');
 	}
 
-	private final Vector<Class<?>> findSubclasses(Map<URL, String> locations, String searchingPackageName) {
-		Vector<Class<?>> v = new Vector<Class<?>>();
+	private List<Class<?>> findSubclasses(Map<URL, String> locations, String searchingPackageName) {
+		List<Class<?>> v = synchronizedList(new ArrayList<Class<?>>());
 
-		Vector<Class<?>> w = null;
+		List<Class<?>> w = null;
 
 		Iterator<URL> it = locations.keySet().iterator();
 		while (it.hasNext()) {
@@ -251,14 +248,14 @@ public class ClassFinder {
 		return v;
 	}
 
-	private final Vector<Class<?>> findSubclasses(URL location, String packageName, String searchingPackageName) {
+	private List<Class<?>> findSubclasses(URL location, String packageName, String searchingPackageName) {
 
 		synchronized (results) {
 
 			// hash guarantees unique names...
 			Map<Class<?>, URL> thisResult = new TreeMap<Class<?>, URL>(CLASS_COMPARATOR);
-			Vector<Class<?>> v = new Vector<Class<?>>(); // ...but return a
-															// vector
+			List<Class<?>> v = synchronizedList(new ArrayList<Class<?>>());
+			// ...but return a list
 
 			List<URL> knownLocations = new ArrayList<URL>();
 			knownLocations.add(location);
@@ -363,7 +360,7 @@ public class ClassFinder {
 	public static void main(String[] args) {
 
 		ClassFinder finder = null;
-		Vector<Class<?>> v = null;
+		List<Class<?>> v = null;
 		List<Throwable> errors = null;
 
 		if (args.length == 1) {

--- a/AndroidAnnotations/checkstyle-suppressions.xml
+++ b/AndroidAnnotations/checkstyle-suppressions.xml
@@ -21,5 +21,7 @@
 
 <suppressions>
     <suppress files="org[\\/]androidannotations[\\/](?:[^\\/]+$|(?!annotations)[^\\/]+[\\/])" checks="JavadocType|JavadocMethod|JavadocVariable|JavadocStyle" />
+	<suppress files="org[\\/]robolectric[\\/]" checks="JavadocType|JavadocMethod|JavadocVariable|JavadocStyle" />
     <suppress files="com[\\/]" checks="JavadocType|JavadocMethod|JavadocVariable|JavadocStyle" />
+    <suppress files="R.java" checks=".*" />
 </suppressions>

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ApplicationInjectedActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ApplicationInjectedActivityTest.java
@@ -26,24 +26,24 @@ import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class ApplicationInjectedActivityTest {
-	
+
 	@Test
-	public void should_have_application_after_create() {
+	public void shouldHaveApplicationAfterCreate() {
 		SampleRoboApplication_ application = new SampleRoboApplication_();
 		application.onCreate();
-		
+
 		ApplicationInjectedActivity_ activity = Robolectric.buildActivity(ApplicationInjectedActivity_.class).create().get();
 
 		assertThat(activity.customApplication).isNotNull();
 	}
 
 	@Test
-	public void application_can_be_replaced_for_tests() {
+	public void applicationCanBeReplacedForTests() {
 		SampleRoboApplication testApp = new SampleRoboApplication();
 
 		SampleRoboApplication_.setForTesting(testApp);
 
-		ApplicationInjectedActivity_ activity = Robolectric.buildActivity(ApplicationInjectedActivity_.class).create().get();;
+		ApplicationInjectedActivity_ activity = Robolectric.buildActivity(ApplicationInjectedActivity_.class).create().get();
 
 		assertThat(activity.customApplication).isSameAs(testApp);
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ClicksHandledActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ClicksHandledActivityTest.java
@@ -32,7 +32,7 @@ public class ClicksHandledActivityTest {
 	private ClicksHandledActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ClicksHandledActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/FragmentArgsTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/FragmentArgsTest.java
@@ -17,7 +17,6 @@ package org.androidannotations.test15;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-import org.androidannotations.test15.instancestate.SaveInstanceStateActivityParameterizedTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -33,8 +32,8 @@ public class FragmentArgsTest {
 	 * This test verifies the Fragment argument gets injected. It does not check
 	 * for different types, because we use the same code for every
 	 * Bundle-related operation and types are already tested in
-	 * {@link SaveInstanceStateActivityParameterizedTest}.
-	 *
+	 * {@link org.androidannotations.test15.instancestate.SaveInstanceStateActivityParameterizedTest
+	 * SaveInstanceStateActivityParameterizedTest} .
 	 */
 	@Test
 	public void testFragmentArgInjected() {

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/FromHtmlActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/FromHtmlActivityTest.java
@@ -32,7 +32,7 @@ public class FromHtmlActivityTest {
 	private FromHtmlActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(FromHtmlActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/InjectExtraTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/InjectExtraTest.java
@@ -37,72 +37,57 @@ public class InjectExtraTest {
 	private ActivityController<ExtraInjectedActivity_> controller;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		controller = ActivityController.of(ExtraInjectedActivity_.class);
 		activity = controller.get();
 	}
 
 	@Test
-	public void simple_string_extra_injected() {
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.stringExtra("Hello!").get())
-				.create();
+	public void simpleStringExtraInjected() {
+		controller.withIntent(ExtraInjectedActivity_.intent(context).stringExtra("Hello!").get()).create();
 		assertThat(activity.stringExtra).isEqualTo("Hello!");
 	}
 
 	@Test
-	public void array_extra_injected() {
+	public void arrayExtraInjected() {
 		CustomData[] customData = { new CustomData("42") };
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.arrayExtra(customData).get())
-				.create();
+		controller.withIntent(ExtraInjectedActivity_.intent(context).arrayExtra(customData).get()).create();
 		assertThat(activity.arrayExtra).isEqualTo(customData);
 	}
 
 	@Test
-	public void list_extra_injected() {
+	public void listExtraInjected() {
 		ArrayList<String> list = new ArrayList<String>();
 		list.add("Hello !");
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.listExtra(list).get())
-				.create();
+		controller.withIntent(ExtraInjectedActivity_.intent(context).listExtra(list).get()).create();
 		assertThat(activity.listExtra).isEqualTo(list);
 	}
 
 	@Test
-	public void int_extra_injected() {
-		controller.withIntent(ExtraInjectedActivity_.intent(context).intExtra(42)
-				.get())
-				.create();
+	public void intExtraInjected() {
+		controller.withIntent(ExtraInjectedActivity_.intent(context).intExtra(42).get()).create();
 		assertThat(activity.intExtra).isEqualTo(42);
 	}
 
 	@Test
-	public void int_array_extra_injected() {
+	public void intArrayExtraInjected() {
 		byte[] byteArray = { 0, 2 };
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.byteArrayExtra(byteArray).get())
-				.create();
+		controller.withIntent(ExtraInjectedActivity_.intent(context).byteArrayExtra(byteArray).get()).create();
 		assertThat(activity.byteArrayExtra).isEqualTo(byteArray);
 	}
 
 	@Test
-	public void setIntent_reinjects_extra() {
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.stringExtra("Hello!").get())
-				.create();
+	public void setIntentReinjectsExtra() {
+		controller.withIntent(ExtraInjectedActivity_.intent(context).stringExtra("Hello!").get()).create();
 
-		controller.newIntent(ExtraInjectedActivity_.intent(context)
-				.stringExtra("Hello Again!").get());
+		controller.newIntent(ExtraInjectedActivity_.intent(context).stringExtra("Hello Again!").get());
 
 		assertThat(activity.stringExtra).isEqualTo("Hello Again!");
 	}
 
 	@Test
 	public void extraWithoutValueInjected() {
-		controller.withIntent(ExtraInjectedActivity_.intent(context)
-				.extraWithoutValue("Hello!").get())
-				.create();
+		controller.withIntent(ExtraInjectedActivity_.intent(context).extraWithoutValue("Hello!").get()).create();
 		assertThat(activity.extraWithoutValue).isEqualTo("Hello!");
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ItemClicksHandledActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ItemClicksHandledActivityTest.java
@@ -37,17 +37,16 @@ public class ItemClicksHandledActivityTest {
 	private ItemClicksHandledActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ItemClicksHandledActivity_.class).create().get();
-		clickedItem = activity.getResources().getStringArray(
-				R.array.planets_array)[TESTED_CLICKED_INDEX];
+		clickedItem = activity.getResources().getStringArray(R.array.planets_array)[TESTED_CLICKED_INDEX];
 	}
 
 	@Test
 	public void handlingSpinnerItemSelect() {
 		Spinner spinner = (Spinner) activity.findViewById(R.id.spinner);
 		assertThat(activity.spinnerItemClicked).isFalse();
-		
+
 		spinner.getOnItemSelectedListener().onItemSelected(spinner, null, TESTED_CLICKED_INDEX, 0);
 		assertThat(activity.spinnerItemClicked).isTrue();
 	}
@@ -65,61 +64,51 @@ public class ItemClicksHandledActivityTest {
 
 	@Test
 	public void handlingSpinnerItemSelectWithArgument() {
-		Spinner spinner = (Spinner) activity
-				.findViewById(R.id.spinnerWithArgument);
+		Spinner spinner = (Spinner) activity.findViewById(R.id.spinnerWithArgument);
 
 		assertThat(activity.spinnerWithArgumentSelectedItem).isNull();
 		spinner.getOnItemSelectedListener().onItemSelected(spinner, null, TESTED_CLICKED_INDEX, 0);
 		assertThat(activity.spinnerWithArgumentSelectedItem).isNotNull();
-		assertThat(activity.spinnerWithArgumentSelectedItem).isEqualTo(
-				clickedItem);
+		assertThat(activity.spinnerWithArgumentSelectedItem).isEqualTo(clickedItem);
 	}
 
 	@Test
 	public void handlingListViewitemClickWithArgument() {
-		ListView listView = (ListView) activity
-				.findViewById(R.id.listViewWithArgument);
+		ListView listView = (ListView) activity.findViewById(R.id.listViewWithArgument);
 		long itemId = listView.getAdapter().getItemId(TESTED_CLICKED_INDEX);
 		View view = listView.getChildAt(TESTED_CLICKED_INDEX);
 
 		assertThat(activity.listViewWithArgumentSelectedItem).isNull();
 		listView.performItemClick(view, TESTED_CLICKED_INDEX, itemId);
 		assertThat(activity.listViewWithArgumentSelectedItem).isNotNull();
-		assertThat(activity.listViewWithArgumentSelectedItem).isEqualTo(
-				clickedItem);
+		assertThat(activity.listViewWithArgumentSelectedItem).isEqualTo(clickedItem);
 	}
 
 	@Test
 	public void handlingListViewItemClickWithPosition() {
-		ListView listView = (ListView) activity
-				.findViewById(R.id.listViewWithPosition);
+		ListView listView = (ListView) activity.findViewById(R.id.listViewWithPosition);
 		long itemId = listView.getAdapter().getItemId(TESTED_CLICKED_INDEX);
 		View view = listView.getChildAt(TESTED_CLICKED_INDEX);
 
 		assertThat(activity.listViewWithPositionClickedPosition).isEqualTo(0);
 		listView.performItemClick(view, TESTED_CLICKED_INDEX, itemId);
-		assertThat(activity.listViewWithPositionClickedPosition).isEqualTo(
-				TESTED_CLICKED_INDEX);
+		assertThat(activity.listViewWithPositionClickedPosition).isEqualTo(TESTED_CLICKED_INDEX);
 	}
 
 	@Test
 	public void handlingListViewWithPositionItemSelected() {
-		final ListView listView = (ListView) activity
-				.findViewById(R.id.listViewWithPosition);
+		final ListView listView = (ListView) activity.findViewById(R.id.listViewWithPosition);
 
-		assertThat(activity.listViewWithPositionItemSelectedPosition)
-				.isEqualTo(0);
+		assertThat(activity.listViewWithPositionItemSelectedPosition).isEqualTo(0);
 		assertThat(activity.listViewWithPositionItemSelected).isFalse();
 		listView.getOnItemSelectedListener().onItemSelected(listView, null, TESTED_CLICKED_INDEX, 0);
 		assertThat(activity.listViewWithPositionItemSelected).isTrue();
-		assertThat(activity.listViewWithPositionItemSelectedPosition)
-				.isEqualTo(TESTED_CLICKED_INDEX);
+		assertThat(activity.listViewWithPositionItemSelectedPosition).isEqualTo(TESTED_CLICKED_INDEX);
 	}
 
 	@Test
-	public void can_have_one_selected_argument() {
-		ListView listView = (ListView) activity
-				.findViewById(R.id.listViewWithOneParam);
+	public void canHaveOneSelectedArgument() {
+		ListView listView = (ListView) activity.findViewById(R.id.listViewWithOneParam);
 		assertThat(activity.listViewWithOneParamItemSelected).isFalse();
 		listView.getOnItemSelectedListener().onItemSelected(listView, null, TESTED_CLICKED_INDEX, 0);
 		assertThat(activity.listViewWithOneParamItemSelected).isTrue();

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/LongClicksHandledActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/LongClicksHandledActivityTest.java
@@ -30,7 +30,7 @@ public class LongClicksHandledActivityTest {
 	private LongClicksHandledActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(LongClicksHandledActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/SSLConnectionTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/SSLConnectionTest.java
@@ -17,10 +17,9 @@ package org.androidannotations.test15;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.security.Security;
-
-import junit.framework.Assert;
 
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.Scheme;
@@ -45,15 +44,14 @@ public class SSLConnectionTest {
 	}
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(SSLConnection_.class).create().get();
 	}
 
 	@Test
 	public void truststoreProvided() {
 		assertNotNull(activity.mHttpsClientTest1);
-		ClientConnectionManager ccm = activity.mHttpsClientTest1
-				.getConnectionManager();
+		ClientConnectionManager ccm = activity.mHttpsClientTest1.getConnectionManager();
 		assertNotNull(ccm);
 
 		Scheme httpsScheme = ccm.getSchemeRegistry().getScheme("https");
@@ -63,31 +61,25 @@ public class SSLConnectionTest {
 		SocketFactory socketFactHttps = httpsScheme.getSocketFactory();
 
 		if (!(socketFactHttps instanceof SSLSocketFactory)) {
-			Assert.fail("wrong instance should be org.apache.http.conn.ssl.SSLSocketFactory, getting "
-					+ socketFactHttps);
+			fail("wrong instance should be org.apache.http.conn.ssl.SSLSocketFactory, getting " + socketFactHttps);
 		}
-		assertEquals(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER,
-				((SSLSocketFactory) socketFactHttps).getHostnameVerifier());
+		assertEquals(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER, ((SSLSocketFactory) socketFactHttps).getHostnameVerifier());
 	}
 
 	@Test
 	public void strictHostnameVerifier() {
 		assertNotNull(activity.mHttpsClientTest2);
-		ClientConnectionManager ccm = activity.mHttpsClientTest2
-				.getConnectionManager();
+		ClientConnectionManager ccm = activity.mHttpsClientTest2.getConnectionManager();
 		Scheme httpsScheme = ccm.getSchemeRegistry().getScheme("https");
-		SSLSocketFactory socketFactHttps = (SSLSocketFactory) httpsScheme
-				.getSocketFactory();
+		SSLSocketFactory socketFactHttps = (SSLSocketFactory) httpsScheme.getSocketFactory();
 
-		assertEquals(SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER,
-				((SSLSocketFactory) socketFactHttps).getHostnameVerifier());
+		assertEquals(SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER, socketFactHttps.getHostnameVerifier());
 	}
 
 	@Test
 	public void noOptions() {
 		assertNotNull(activity.mHttpsClientTest3);
-		ClientConnectionManager ccm = activity.mHttpsClientTest3
-				.getConnectionManager();
+		ClientConnectionManager ccm = activity.mHttpsClientTest3.getConnectionManager();
 		assertNotNull(ccm);
 	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ThreadActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ThreadActivityTest.java
@@ -57,7 +57,7 @@ public class ThreadActivityTest {
 	private Thread.UncaughtExceptionHandler defaultExceptionHandler;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ThreadActivity_.class).create().get();
 		defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
 	}
@@ -342,7 +342,7 @@ public class ThreadActivityTest {
 	}
 
 	@Test
-	public void assertHandlerWithMainThread() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+	public void assertHandlerWithMainThread() throws Exception {
 		/*
 		 * For this test we need to recreate the activity in a separate thread,
 		 * in order to check the handler is well associated to the main thread.

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/TouchesHandledActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/TouchesHandledActivityTest.java
@@ -34,7 +34,7 @@ public class TouchesHandledActivityTest {
 	private MotionEvent mockedEvent;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(TouchesHandledActivity_.class).create().get();
 
 		mockedEvent = MotionEvent.obtain(0, 0, 0, 0f, 0f, 0);

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/TransactionalActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/TransactionalActivityTest.java
@@ -38,7 +38,7 @@ public class TransactionalActivityTest {
 	private TransactionalActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(TransactionalActivity_.class).create().get();
 		mockDb = mock(SQLiteDatabase.class);
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ViewsInjectedActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ViewsInjectedActivityTest.java
@@ -30,7 +30,7 @@ public class ViewsInjectedActivityTest {
 	private ViewsInjectedActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ViewsInjectedActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/WakeLockActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/WakeLockActivityTest.java
@@ -38,7 +38,7 @@ public class WakeLockActivityTest {
 	private WakeLockActivity activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.setupActivity(WakeLockActivity_.class);
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterextras/AfterExtrasActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterextras/AfterExtrasActivityTest.java
@@ -33,7 +33,7 @@ public class AfterExtrasActivityTest {
 	Intent intent;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activityController = ActivityController.of(AfterExtrasActivity_.class);
 		activity = activityController.get();
 
@@ -41,7 +41,7 @@ public class AfterExtrasActivityTest {
 	}
 
 	@Test
-	public void afterExtra_called_activity_after_setIntent() {
+	public void afterExtraCalledActivityAfterSetIntent() {
 		activityController.create();
 		assertThat(activity.extraDataSet).isFalse();
 		assertThat(activity.afterExtrasCalled).isFalse();
@@ -52,7 +52,7 @@ public class AfterExtrasActivityTest {
 	}
 
 	@Test
-	public void afterExtra_called_activity_in_onCreate() throws Exception {
+	public void afterExtraCalledActivityInOnCreate() throws Exception {
 		assertThat(activity.extraDataSet).isFalse();
 		assertThat(activity.afterExtrasCalled).isFalse();
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterinject/AfterInjectActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterinject/AfterInjectActivityTest.java
@@ -25,23 +25,23 @@ import org.robolectric.util.ActivityController;
 
 @RunWith(RobolectricTestRunner.class)
 public class AfterInjectActivityTest {
-	
+
 	AfterInjectActivity_ activity;
 	ActivityController<AfterInjectActivity_> activityController;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activityController = ActivityController.of(AfterInjectActivity_.class);
 		activity = activityController.get();
 	}
-	
+
 	@Test
 	public void afterInjectIsCalledInOnCreate() {
 		assertThat(activity.afterInjectCalled).isFalse();
 		activityController.create();
 		assertThat(activity.afterInjectCalled).isTrue();
 	}
-	
+
 	@Test
 	public void injectionDoneWhenAfterInjectCalled() {
 		activityController.create();

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterinject/AfterInjectBeanTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterinject/AfterInjectBeanTest.java
@@ -27,20 +27,20 @@ import android.app.Activity;
 
 @RunWith(RobolectricTestRunner.class)
 public class AfterInjectBeanTest {
-	
+
 	AfterInjectBean bean;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		Activity activity = Robolectric.buildActivity(Activity.class).create().get();
 		bean = AfterInjectBean_.getInstance_(activity);
 	}
-	
+
 	@Test
 	public void afterInjectIsCalled() {
 		assertThat(bean.afterInjectCalled).isTrue();
 	}
-	
+
 	@Test
 	public void injectionDoneWhenAfterInjectCalled() {
 		assertThat(bean.notificationManagerNullAfterInject).isFalse();

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterviews/AfterViewsActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/afterviews/AfterViewsActivityTest.java
@@ -30,13 +30,13 @@ public class AfterViewsActivityTest {
 	ActivityController<AfterViewsActivity_> controller;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		controller = ActivityController.of(AfterViewsActivity_.class);
 		activity = controller.get();
 	}
 
 	@Test
-	public void afterViews_called_in_bean_before_activity() {
+	public void afterViewsCalledInBeanBeforeActivity() {
 		controller.create();
 		assertThat(activity.afterViewBeanCalledBefore).isTrue();
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/BeanInjectedActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/BeanInjectedActivityTest.java
@@ -25,36 +25,36 @@ import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class BeanInjectedActivityTest {
-	
+
 	private BeanInjectedActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(BeanInjectedActivity_.class).create().get();
 	}
 
 	@Test
-	public void dependency_is_injected() {
+	public void dependencyIsInjected() {
 		assertThat(activity.dependency).isNotNull();
 	}
-	
+
 	@Test
-	public void dependency_with_annotation_value_is_injected() {
+	public void dependencyWithAnnotationValueIsInjected() {
 		assertThat(activity.interfaceDependency).isNotNull();
 	}
-	
+
 	@Test
-	public void dependency_with_annotation_value_is_of_annotation_value_type() {
+	public void dependencyWithAnnotationValueIsOfAnnotationValueType() {
 		assertThat(activity.interfaceDependency).isInstanceOf(SomeImplementation.class);
 	}
-	
+
 	@Test
-	public void singleton_dependency_is_same_reference() {
+	public void singletonDependencyIsSameReference() {
 		SomeSingleton initialDependency = activity.singletonDependency;
-		
+
 		BeanInjectedActivity_ newActivity = Robolectric.buildActivity(BeanInjectedActivity_.class).create().get();
-		
+
 		assertThat(newActivity.singletonDependency).isSameAs(initialDependency);
 	}
-	
+
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/CyclicSingletonTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/CyclicSingletonTest.java
@@ -26,7 +26,7 @@ import org.robolectric.RobolectricTestRunner;
 public class CyclicSingletonTest {
 
 	@Test
-	public void cyclic_singleton() {
+	public void cyclicSingleton() {
 		EmptyActivityWithoutLayout_ context = new EmptyActivityWithoutLayout_();
 		SomeCyclicSingletonA_ singletonA = SomeCyclicSingletonA_.getInstance_(context);
 		SomeCyclicSingletonB_ singletonB = SomeCyclicSingletonB_.getInstance_(context);

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/SomeBeanTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/SomeBeanTest.java
@@ -26,25 +26,25 @@ import org.robolectric.RobolectricTestRunner;
 public class SomeBeanTest {
 
 	@Test
-	public void getInstance_returns_same_instance() {
+	public void getInstanceReturnsSameInstance() {
 		EmptyActivityWithoutLayout_ context = new EmptyActivityWithoutLayout_();
 		SomeBean_ firstInstance = SomeBean_.getInstance_(context);
 		SomeBean_ secondInstance = SomeBean_.getInstance_(context);
 		assertThat(firstInstance).isNotSameAs(secondInstance);
 	}
-	
+
 	@Test
-	public void injects_factory_context() {
+	public void injectsFactoryContext() {
 		EmptyActivityWithoutLayout_ context = new EmptyActivityWithoutLayout_();
 		SomeBean_ bean = SomeBean_.getInstance_(context);
 		assertThat(bean.context).isSameAs(context);
 	}
 
 	@Test
-	public void rebind_changes_context() {
+	public void rebindChangesContext() {
 		EmptyActivityWithoutLayout_ context = new EmptyActivityWithoutLayout_();
 		SomeBean_ bean = SomeBean_.getInstance_(context);
-		
+
 		EmptyActivityWithoutLayout_ context2 = new EmptyActivityWithoutLayout_();
 		bean.rebind(context2);
 		assertThat(bean.context).isSameAs(context2);

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/SomeSingletonTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ebean/SomeSingletonTest.java
@@ -33,14 +33,14 @@ import android.view.View;
 
 @RunWith(RobolectricTestRunner.class)
 public class SomeSingletonTest {
-	
+
 	@Before
-	public void setup() throws Exception {
+	public void setUp() throws Exception {
 		resetSingletonToNull();
 	}
 
 	@Test
-	public void getInstance_returns_same_instance() {
+	public void getInstanceReturnsSameInstance() {
 		EmptyActivityWithoutLayout_ context = new EmptyActivityWithoutLayout_();
 		SomeSingleton_ firstInstance = SomeSingleton_.getInstance_(context);
 		SomeSingleton_ secondInstance = SomeSingleton_.getInstance_(context);
@@ -48,7 +48,7 @@ public class SomeSingletonTest {
 	}
 
 	@Test
-	public void views_are_not_injected() throws Exception {
+	public void viewsAreNotInjected() throws Exception {
 		Context context = mock(Context.class);
 		OnViewChangedNotifier notifier = new OnViewChangedNotifier();
 		OnViewChangedNotifier.replaceNotifier(notifier);
@@ -65,8 +65,7 @@ public class SomeSingletonTest {
 		assertThat(singleton.beanWithView.myTextView).isNull();
 	}
 
-	private void resetSingletonToNull() throws IllegalAccessException,
-			NoSuchFieldException {
+	private void resetSingletonToNull() throws IllegalAccessException, NoSuchFieldException {
 		Field instanceField = SomeSingleton_.class.getDeclaredField("instance_");
 		instanceField.setAccessible(true);
 		instanceField.set(null, null);

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MyFragmentActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MyFragmentActivityTest.java
@@ -29,27 +29,27 @@ public class MyFragmentActivityTest {
 	private MyFragmentActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(MyFragmentActivity_.class).create().get();
 	}
 
 	@Test
-	public void can_inject_native_fragment_with_default_id() {
+	public void canInjectNativeFragmentWithDefaultId() {
 		assertThat(activity.myFragment).isNotNull();
 	}
 
 	@Test
-	public void can_inject_native_fragment_with_id() {
+	public void canInjectNativeFragmentWithId() {
 		assertThat(activity.myFragment2).isNotNull();
 	}
 
 	@Test
-	public void can_inject_native_fragment_with_with_default_tag() {
+	public void canInjectNativeFragmentWithWithDefaultTag() {
 		assertThat(activity.myFragmentTag).isNotNull();
 	}
 
 	@Test
-	public void can_inject_native_fragment_with_with_tag() {
+	public void canInjectNativeFragmentWithWithTag() {
 		assertThat(activity.myFragmentTag2).isNotNull();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MyListFragmentTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MyListFragmentTest.java
@@ -45,13 +45,13 @@ public class MyListFragmentTest {
 	FragmentManager fragmentManager;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		myListFragment = new MyListFragment_();
 		startFragment(myListFragment);
 	}
 
 	@Test
-	public void is_item_click_available_from_list_fragment() {
+	public void isItemClickAvailableFromListFragment() {
 		ListView listView = (ListView) myListFragment.findViewById(android.R.id.list);
 		long itemId = listView.getAdapter().getItemId(TESTED_CLICKED_INDEX);
 		View view = listView.getChildAt(TESTED_CLICKED_INDEX);
@@ -62,21 +62,21 @@ public class MyListFragmentTest {
 	}
 
 	@Test
-	public void not_ignored_method_is_called() {
+	public void notIgnoredMethodIsCalled() {
 		assertFalse(myListFragment.didExecute);
 		myListFragment.notIgnored();
 		assertTrue(myListFragment.didExecute);
 	}
 
 	@Test
-	public void uithread_method_is_called() {
+	public void uithreadMethodIsCalled() {
 		assertFalse(myListFragment.didExecute);
 		myListFragment.uiThread();
 		assertTrue(myListFragment.didExecute);
 	}
 
 	@Test
-	public void background_method_is_called() {
+	public void backgroundMethodIsCalled() {
 		assertFalse(myListFragment.didExecute);
 		runBackgroundsOnSameThread();
 		myListFragment.backgroundThread();
@@ -84,7 +84,7 @@ public class MyListFragmentTest {
 	}
 
 	@Test
-	public void ignored_when_detached_works_for_uithread_method() {
+	public void ignoredWhenDetachedWorksForUithreadMethod() {
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -93,7 +93,7 @@ public class MyListFragmentTest {
 	}
 
 	@Test
-	public void ignored_when_detached_works_for_background_method() {
+	public void ignoredWhenDetachedWorksForBackgroundMethod() {
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -103,7 +103,7 @@ public class MyListFragmentTest {
 	}
 
 	@Test
-	public void ignored_when_detached_works_for_ignored_method() {
+	public void ignoredWhenDetachedWorksForIgnoredMethod() {
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -112,7 +112,7 @@ public class MyListFragmentTest {
 	}
 
 	@Test
-	public void layout_not_injected_without_force() {
+	public void layoutNotInjectedWithoutForce() {
 		View buttonInInjectedLayout = myListFragment.getView().findViewById(R.id.conventionButton);
 
 		assertThat(buttonInInjectedLayout).isNull();

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MySupportFragmentActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/efragment/MySupportFragmentActivityTest.java
@@ -29,27 +29,27 @@ public class MySupportFragmentActivityTest {
 	private MySupportFragmentActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(MySupportFragmentActivity_.class).create().get();
 	}
 
 	@Test
-	public void can_inject_support_fragment_with_default_id() {
+	public void canInjectSupportFragmentWithDefaultId() {
 		assertThat(activity.mySupportFragment).isNotNull();
 	}
 
 	@Test
-	public void can_inject_support_fragment_with_id() {
+	public void canInjectSupportFragmentWithId() {
 		assertThat(activity.mySupportFragment2).isNotNull();
 	}
 
 	@Test
-	public void can_inject_support_fragment_with_default_tag() {
+	public void canInjectSupportFragmentWithDefaultTag() {
 		assertThat(activity.mySupportFragmentTag).isNotNull();
 	}
 
 	@Test
-	public void can_inject_support_fragment_with_tag() {
+	public void canInjectSupportFragmentWithTag() {
 		assertThat(activity.mySupportFragmentTag2).isNotNull();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ereceiver/ReceiverWithActionsTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ereceiver/ReceiverWithActionsTest.java
@@ -34,7 +34,7 @@ public class ReceiverWithActionsTest {
 	private ReceiverWithActions receiver;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		receiver = new ReceiverWithActions_();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/eview/CustomButtonTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/eview/CustomButtonTest.java
@@ -29,7 +29,7 @@ import android.content.Context;
 public class CustomButtonTest {
 
 	@Test
-	public void constructor_parameters_are_transmitted_from_factory_method() {
+	public void constructorParametersAreTransmittedFromFactoryMethod() {
 		Context context = Robolectric.buildActivity(EmptyActivityWithoutLayout_.class).create().get();
 		int parameter = 42;
 		CustomButton button = CustomButton_.build(context, parameter);
@@ -37,7 +37,7 @@ public class CustomButtonTest {
 	}
 
 	@Test
-	public void factory_method_builds_inflated_instance() {
+	public void factoryMethodBuildsInflatedInstance() {
 		Context context = Robolectric.buildActivity(EmptyActivityWithoutLayout_.class).create().get();
 		CustomButton button = CustomButton_.build(context);
 		assertThat(button.afterViewsCalled).isTrue();

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/inheritance/InheritanceTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/inheritance/InheritanceTest.java
@@ -31,13 +31,13 @@ import android.content.Context;
 public class InheritanceTest {
 
 	@Test
-	public void after_inject_mother_calls_first() {
+	public void afterInjectMotherCallsFirst() {
 		Child child = Child_.getInstance_(mock(Context.class));
 		assertThat(child.motherInitWasCalled).isTrue();
 	}
-	
+
 	@Test
-	public void after_views_mother_calls_first() {
+	public void afterViewsMotherCallsFirst() {
 		OnViewChangedNotifier notifier = new OnViewChangedNotifier();
 		OnViewChangedNotifier.replaceNotifier(notifier);
 		Child_ child = Child_.getInstance_(mock(Activity.class));

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/instancestate/SaveInstanceStateActivityParameterizedTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/instancestate/SaveInstanceStateActivityParameterizedTest.java
@@ -25,24 +25,25 @@ import java.util.Collection;
 import org.fest.util.Lists;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.ParameterizedRobolectricTestRunnerWorkaround;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+import org.robolectric.ParameterizedRobolectricTestRunnerWorkaround;
 import org.robolectric.Robolectric;
 
 import android.os.Bundle;
 
 @RunWith(ParameterizedRobolectricTestRunnerWorkaround.class)
 public class SaveInstanceStateActivityParameterizedTest {
-	
+
 	@Parameters(name = "{0}")
 	public static Collection<Object[]> generateTestCases() throws Exception {
 		ArrayList<MyGenericParcelableBean<Integer>> myGenericParcelableBeanArrayList = new ArrayList<MyGenericParcelableBean<Integer>>();
-		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>((Integer) 1));
-		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>((Integer) 2));
-		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>((Integer) 3));
-		
+		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>(1));
+		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>(2));
+		myGenericParcelableBeanArrayList.add(new MyGenericParcelableBean<Integer>(3));
+
+		// CHECKSTYLE:OFF
 		Object[][] testCases = { //
-		//
+				//
 				{ "myBoolean", true }, //
 				{ "myBooleanArray", new boolean[] { true, false, true } }, //
 				{ "myBooleanObject", Boolean.TRUE }, //
@@ -83,15 +84,17 @@ public class SaveInstanceStateActivityParameterizedTest {
 				{ "mySerializableBeanArray", new MySerializableBean[] { new MySerializableBean(5), new MySerializableBean(6) } }, //
 				{ "myParcelableBean", new MyParcelableBean(9) }, //
 				{ "myParcelableBeanArray", new MyParcelableBean[] { new MyParcelableBean(3), new MyParcelableBean(9) } }, //
-				{ "myGenericSerializableBean", new MyGenericSerializableBean<Integer>((Integer)3)}, //
-				{ "myGenericSerializableBeanArray", new MyGenericSerializableBean[] {new MyGenericSerializableBean<Integer>((Integer)3), new MyGenericSerializableBean<Integer>((Integer)5)} }, //
-				{ "myGenericParcelableBean", new MyGenericParcelableBean<String>("Plop !")}, //
-				{ "myGenericParcelableBeanArray", new MyGenericParcelableBean[] {new MyGenericParcelableBean<Integer>((Integer)3), new MyGenericParcelableBean<Integer>((Integer)5)} }, //
+				{ "myGenericSerializableBean", new MyGenericSerializableBean<Integer>(3) }, //
+				{ "myGenericSerializableBeanArray", new MyGenericSerializableBean[] { new MyGenericSerializableBean<Integer>(3), new MyGenericSerializableBean<Integer>(5) } }, //
+				{ "myGenericParcelableBean", new MyGenericParcelableBean<String>("Plop !") }, //
+				{ "myGenericParcelableBeanArray", new MyGenericParcelableBean[] { new MyGenericParcelableBean<Integer>(3), new MyGenericParcelableBean<Integer>(5) } }, //
 				{ "myParcelableBeanArrayList", Lists.newArrayList(new MyParcelableBean(1), new MyParcelableBean(2), new MyParcelableBean(3)) }, //
 				{ "myGenericParcelableBeanArrayList", myGenericParcelableBeanArrayList }, //
 				{ "mySerializableBeanArrayList", Lists.newArrayList(new MySerializableBean(1), new MySerializableBean(2), new MySerializableBean(3)) }, //
 				{ "nullWrappedLong", null }, //
 		};
+		// CHECKSTYLE:ON
+
 		return Arrays.asList(testCases);
 	}
 
@@ -110,7 +113,7 @@ public class SaveInstanceStateActivityParameterizedTest {
 	}
 
 	@Test
-	public void can_save_field() throws Exception {
+	public void canSaveField() throws Exception {
 		SaveInstanceStateActivity_ savedActivity = Robolectric.buildActivity(SaveInstanceStateActivity_.class).create().get();
 
 		Bundle bundle = saveField(savedActivity);
@@ -119,7 +122,7 @@ public class SaveInstanceStateActivityParameterizedTest {
 	}
 
 	@Test
-	public void can_load_field() throws Exception {
+	public void canLoadField() throws Exception {
 		SaveInstanceStateActivity_ savedActivity = Robolectric.buildActivity(SaveInstanceStateActivity_.class).create().get();
 
 		Bundle bundle = saveField(savedActivity);

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/instancestate/SaveInstanceStateActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/instancestate/SaveInstanceStateActivityTest.java
@@ -26,12 +26,12 @@ import android.os.Bundle;
 public class SaveInstanceStateActivityTest {
 
 	@Test
-	public void can_create_with_empty_bundle() {
+	public void canCreateWithEmptyBundle() {
 		Robolectric.buildActivity(SaveInstanceStateActivity_.class).create(new Bundle());
 	}
 
 	@Test
-	public void can_create_without_saved_state() {
+	public void canCreateWithoutSavedState() {
 		Robolectric.buildActivity(SaveInstanceStateActivity_.class).create();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/menu/OptionsMenuActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/menu/OptionsMenuActivityTest.java
@@ -34,7 +34,7 @@ public class OptionsMenuActivityTest {
 	private OptionsMenuActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(OptionsMenuActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ormlite/OrmLiteActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ormlite/OrmLiteActivityTest.java
@@ -25,31 +25,31 @@ import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class OrmLiteActivityTest {
-	
+
 	private OrmLiteActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(OrmLiteActivity_.class).create().get();
 	}
 
 	@Test
-	public void custom_dao_is_injected() {
+	public void customDaoIsInjected() {
 		assertThat((Object) activity.userDao).isNotNull();
 	}
 
 	@Test
-	public void dao_is_injected() {
+	public void daoIsInjected() {
 		assertThat((Object) activity.carDao).isNotNull();
 	}
 
 	@Test
-	public void bean_is_injected() {
+	public void beanIsInjected() {
 		assertThat((Object) activity.ormLiteBean).isNotNull();
 	}
 
 	@Test
-	public void dao_in_bean_is_injected() {
+	public void daoInBeanIsInjected() {
 		assertThat((Object) activity.ormLiteBean.userDao).isNotNull();
 	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ormlite/OrmLiteOnDestroyTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/ormlite/OrmLiteOnDestroyTest.java
@@ -37,7 +37,7 @@ public class OrmLiteOnDestroyTest {
 	private Invoker<Integer> instanceCountInvoker;
 
 	@Before
-	public void setup() throws NoSuchFieldException, IllegalAccessException {
+	public void setUp() throws NoSuchFieldException, IllegalAccessException {
 		staticField("helper").ofType(OrmLiteSqliteOpenHelper.class).in(OpenHelperManager.class).set(null);
 		staticField("helperClass").ofType(Class.class).in(OpenHelperManager.class).set(null);
 		staticField("wasClosed").ofType(boolean.class).in(OpenHelperManager.class).set(false);
@@ -49,11 +49,11 @@ public class OrmLiteOnDestroyTest {
 	}
 
 	@Test
-	public void helper_is_destroyed() throws Exception {
+	public void helperIsDestroyed() throws Exception {
 		controller.destroy();
 
-		Object databaseHelper_ = field("databaseHelper_").ofType(OrmLiteSqliteOpenHelper.class).in(controller.get()).get();
-		assertThat(databaseHelper_).isNull();
+		Object databaseHelper = field("databaseHelper_").ofType(OrmLiteSqliteOpenHelper.class).in(controller.get()).get();
+		assertThat(databaseHelper).isNull();
 		assertThat(instanceCountInvoker.get()).isEqualTo(0);
 	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/prefs/PrefsActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/prefs/PrefsActivityTest.java
@@ -15,7 +15,12 @@
  */
 package org.androidannotations.test15.prefs;
 
-import android.content.SharedPreferences;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.androidannotations.api.sharedpreferences.SetXmlSerializer;
 import org.androidannotations.test15.R;
 import org.junit.Before;
@@ -24,11 +29,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
-
-import static org.fest.assertions.api.Assertions.assertThat;
+import android.content.SharedPreferences;
 
 @RunWith(RobolectricTestRunner.class)
 public class PrefsActivityTest {
@@ -39,7 +40,7 @@ public class PrefsActivityTest {
 	private SomePrefs_ somePrefs;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(PrefsActivity_.class).create().get();
 		somePrefs = activity.somePrefs;
 		sharedPref = somePrefs.getSharedPreferences();
@@ -167,21 +168,21 @@ public class PrefsActivityTest {
 	@Test
 	public void getStringSetCompat() {
 		Set<String> values = new TreeSet<String>(Arrays.asList("1", "2", "3"));
-		
+
 		sharedPref.edit().putString("types", SetXmlSerializer.serialize(values)).commit();
-		
+
 		assertThat(somePrefs.types().get()).isEqualTo(values);
 	}
 
 	@Test
 	public void getStringSet() {
 		Set<String> values = new TreeSet<String>(Arrays.asList("1", "2", "3"));
-		
+
 		sharedPref.edit().putStringSet("types", values).commit();
-		
+
 		assertThat(somePrefs.types().get()).isEqualTo(values);
 	}
-	
+
 	@Test
 	public void defaultValue() {
 		assertThat(somePrefs.name().get()).isEqualTo("John");
@@ -221,6 +222,6 @@ public class PrefsActivityTest {
 	@Test
 	public void setStringInLongFieldAndGetLong() {
 		sharedPref.edit().putString("ageLong", "90211105578124").commit();
-		assertThat(somePrefs.ageLong().get()).isEqualTo(90211105578124l);
+		assertThat(somePrefs.ageLong().get()).isEqualTo(90211105578124L);
 	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/receiver/ActivityWithReceiverTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/receiver/ActivityWithReceiverTest.java
@@ -35,7 +35,7 @@ public class ActivityWithReceiverTest {
 	private ActivityWithReceiver_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ActivityWithReceiver_.class).create().start().resume().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/res/ResActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/res/ResActivityTest.java
@@ -26,9 +26,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
-import android.content.res.Resources;
 import android.text.Html;
-import android.view.animation.AnimationUtils;
 
 @RunWith(RobolectricTestRunner.class)
 public class ResActivityTest {
@@ -36,23 +34,23 @@ public class ResActivityTest {
 	private ResActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(ResActivity_.class).create().get();
 	}
 
 	@Test
-	public void string_snake_case_injected() {
+	public void stringSnakeCaseInjected() {
 		assertThat(activity.injected_string).isEqualTo("test");
 	}
 
 	@Test
-	public void string_camel_case_injected() {
+	public void stringCamelCaseInjected() {
 		assertThat(activity.injectedString).isEqualTo("test");
 	}
 
 	/**
 	 * Cannot be tested right now, because there is no Robolectric shadow class
-	 * for {@link AnimationUtils}.
+	 * for {@link android.view.animation.AnimationUtils AnimationUtils}.
 	 */
 	// @Test
 	public void animNotNull() {
@@ -61,7 +59,9 @@ public class ResActivityTest {
 
 	/**
 	 * Cannot be tested right now, because the Robolectric shadow class for
-	 * {@link Resources} doesn't implement {@link Resources#getAnimation(int)}
+	 * {@link android.content.res.Resources Resources} doesn't implement
+	 * {@link android.content.res.Resources#getAnimation(int)
+	 * Resources#getAnimation(int)}
 	 */
 	// @Test
 	public void xmlResAnimNotNull() {

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/HttpMethodServiceTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/HttpMethodServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+import org.mockito.Matchers;
 import org.robolectric.RobolectricTestRunner;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -31,9 +31,9 @@ import org.springframework.web.client.RestTemplate;
 
 @RunWith(RobolectricTestRunner.class)
 public class HttpMethodServiceTest {
-	
+
 	@Test
-	public void use_delete_http_method() {
+	public void useDeleteHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
@@ -41,11 +41,11 @@ public class HttpMethodServiceTest {
 
 		service.delete();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.DELETE), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.DELETE), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
-	public void use_get_http_method() {
+	public void useGetHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
@@ -53,45 +53,45 @@ public class HttpMethodServiceTest {
 
 		service.get();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.GET), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.GET), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void use_head_http_method() {
+	public void useHeadHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
 		ResponseEntity<Object> response = mock(ResponseEntity.class);
-		when(restTemplate.exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.HEAD), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any())).thenReturn(response);
+		when(restTemplate.exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.HEAD), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any())).thenReturn(response);
 
 		service.setRestTemplate(restTemplate);
 
 		service.head();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.HEAD), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.HEAD), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void use_options_http_method() {
+	public void useOptionsHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
 		ResponseEntity<Object> response = mock(ResponseEntity.class);
-		when(restTemplate.exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.OPTIONS), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any())).thenReturn(response);
+		when(restTemplate.exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.OPTIONS), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any())).thenReturn(response);
 		HttpHeaders headers = mock(HttpHeaders.class);
 		when(response.getHeaders()).thenReturn(headers);
-		
+
 		service.setRestTemplate(restTemplate);
 
 		service.options();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.OPTIONS), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.OPTIONS), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
-	public void use_post_http_method() {
+	public void usePostHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
@@ -99,11 +99,11 @@ public class HttpMethodServiceTest {
 
 		service.post();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.POST), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.POST), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
-	public void use_put_http_method() {
+	public void usePutHttpMethod() {
 		HttpMethodsService_ service = new HttpMethodsService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
@@ -111,7 +111,7 @@ public class HttpMethodServiceTest {
 
 		service.put();
 
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> eq(HttpMethod.PUT), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> eq(HttpMethod.PUT), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/MyServiceTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/MyServiceTest.java
@@ -15,7 +15,7 @@
  */
 package org.androidannotations.test15.rest;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.startsWith;
@@ -32,7 +32,7 @@ import org.apache.http.message.BasicHeader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mockito;
+import org.mockito.Matchers;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.springframework.http.HttpEntity;
@@ -60,7 +60,7 @@ public class MyServiceTest {
 	}
 
 	@Test
-	public void can_override_root_url() {
+	public void canOverrideRootUrl() {
 		MyService_ myService = new MyService_(null);
 
 		RestTemplate restTemplate = mock(RestTemplate.class);
@@ -69,7 +69,7 @@ public class MyServiceTest {
 
 		myService.removeEvent(42);
 
-		verify(restTemplate).exchange(startsWith("http://newRootUrl"), Mockito.<HttpMethod> any(), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any(), Mockito.<Map<String, ?>> any());
+		verify(restTemplate).exchange(startsWith("http://newRootUrl"), Matchers.<HttpMethod> any(), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any(), Matchers.<Map<String, ?>> any());
 	}
 
 	@Test
@@ -192,7 +192,7 @@ public class MyServiceTest {
 		addPendingResponse("fancyHeaderToken");
 		myService.setHttpBasicAuth("fancyUser", "fancierPassword");
 		myService.ping();
-		verify(restTemplate).exchange(eq("http://company.com/client/ping"), Mockito.<HttpMethod> any(), Mockito.<HttpEntity<?>> any(), Mockito.<Class<Object>> any());
+		verify(restTemplate).exchange(eq("http://company.com/client/ping"), Matchers.<HttpMethod> any(), Matchers.<HttpEntity<?>> any(), Matchers.<Class<Object>> any());
 	}
 
 	@Test
@@ -229,7 +229,7 @@ public class MyServiceTest {
 		urlVariables.put("location", locationValue);
 		urlVariables.put("year", yearValue);
 		urlVariables.put("xt", xtValue);
-		verify(restTemplate).exchange(Mockito.anyString(), Mockito.<HttpMethod> any(), argThat(matcher), Mockito.<Class<Object>> any(), eq(urlVariables));
+		verify(restTemplate).exchange(Matchers.anyString(), Matchers.<HttpMethod> any(), argThat(matcher), Matchers.<Class<Object>> any(), eq(urlVariables));
 	}
 
 	@Test

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/RequestTestBuilder.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/rest/RequestTestBuilder.java
@@ -28,6 +28,7 @@ import junit.framework.AssertionFailedError;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.springframework.http.HttpEntity;
@@ -112,24 +113,25 @@ public class RequestTestBuilder {
 
 	private void checkRequest() {
 		if (hasUrlVariables) {
-			verify(restTemplate).exchange(Mockito.anyString(), //
-					Mockito.any(HttpMethod.class), //
+			verify(restTemplate).exchange(Matchers.anyString(), //
+					Matchers.any(HttpMethod.class), //
 					argThat(entityArgumentMatcher), //
-					Mockito.<Class<Object>> any(),//
-					Mockito.<Map<String, Object>> any());
+					Matchers.<Class<Object>> any(), //
+					Matchers.<Map<String, Object>> any());
 		} else {
-			verify(restTemplate).exchange(Mockito.anyString(), //
-					Mockito.any(HttpMethod.class), //
+			verify(restTemplate).exchange(Matchers.anyString(), //
+					Matchers.any(HttpMethod.class), //
 					argThat(entityArgumentMatcher), //
-					Mockito.<Class<Object>> any());
+					Matchers.<Class<Object>> any());
 		}
 	}
 
 	private void checkResponseCookies() throws AssertionFailedError {
 		for (String responseCookieName : responseCookies.keySet()) {
 			String cookieValue = myService.getCookie(responseCookieName);
-			if (cookieValue == null || !cookieValue.equals(responseCookies.get(responseCookieName)))
+			if (cookieValue == null || !cookieValue.equals(responseCookies.get(responseCookieName))) {
 				throw new AssertionFailedError("Response cookie " + responseCookieName + " wasn't set");
+			}
 		}
 	}
 
@@ -143,15 +145,17 @@ public class RequestTestBuilder {
 			if (requestCookies.size() > 0) {
 				String[] httpCookies = httpHeaders.getFirst("Cookie").split(";");
 				for (String cookieName : requestCookies.keySet()) {
-					if (Arrays.binarySearch(httpCookies, cookieName + "=" + requestCookies.get(cookieName)) == -1)
+					if (Arrays.binarySearch(httpCookies, cookieName + "=" + requestCookies.get(cookieName)) == -1) {
 						throw new AssertionFailedError("The cookie " + cookieName + " is missing!");
+					}
 				}
 			}
 
 			// Check that headers set earlier are sent in the request
 			for (String headerName : requestHeaders.keySet()) {
-				if (!(httpHeaders.containsKey(headerName) && httpHeaders.getFirst(headerName).equals(requestHeaders.get(headerName))))
+				if (!(httpHeaders.containsKey(headerName) && httpHeaders.getFirst(headerName).equals(requestHeaders.get(headerName)))) {
 					throw new AssertionFailedError("The header " + headerName + " is missing!");
+				}
 			}
 
 			return true;

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/roboguice/TestSampleRoboApplication_.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/roboguice/TestSampleRoboApplication_.java
@@ -8,30 +8,30 @@ import org.robolectric.TestLifecycleApplication;
 import roboguice.RoboGuice;
 import android.app.Application;
 
+// CHECKSTYLE:OFF
 public class TestSampleRoboApplication_ extends Application implements TestLifecycleApplication {
-    @Override
-    public void onCreate() {
-        super.onCreate();
+// CHECKSTYLE:ON
+	@Override
+	public void onCreate() {
+		super.onCreate();
 
-        RoboGuice.setBaseApplicationInjector(this, RoboGuice.DEFAULT_STAGE,
-                RoboGuice.newDefaultRoboModule(this), new RobolectricSampleModule());
-    }
+		RoboGuice.setBaseApplicationInjector(this, RoboGuice.DEFAULT_STAGE, RoboGuice.newDefaultRoboModule(this), new RobolectricSampleModule());
+	}
 
-    @Override
-    public void beforeTest(Method method) {
-    }
+	@Override
+	public void beforeTest(Method method) {
+	}
 
-    @Override
-    public void prepareTest(Object test) {
-        TestSampleRoboApplication_ application = (TestSampleRoboApplication_) Robolectric.application;
+	@Override
+	public void prepareTest(Object test) {
+		TestSampleRoboApplication_ application = (TestSampleRoboApplication_) Robolectric.application;
 
-        RoboGuice.setBaseApplicationInjector(application, RoboGuice.DEFAULT_STAGE,
-                RoboGuice.newDefaultRoboModule(application), new RobolectricSampleTestModule());
+		RoboGuice.setBaseApplicationInjector(application, RoboGuice.DEFAULT_STAGE, RoboGuice.newDefaultRoboModule(application), new RobolectricSampleTestModule());
 
-        RoboGuice.getInjector(application).injectMembers(test);
-    }
+		RoboGuice.getInjector(application).injectMembers(test);
+	}
 
-    @Override
-    public void afterTest(Method method) {
-    }
+	@Override
+	public void afterTest(Method method) {
+	}
 }

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/sherlock/MySherlockActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/sherlock/MySherlockActivityTest.java
@@ -34,7 +34,7 @@ public class MySherlockActivityTest {
 	private MySherlockActivity_ activity;
 
 	@Before
-	public void setup() {
+	public void setUp() {
 		activity = Robolectric.buildActivity(MySherlockActivity_.class).create().get();
 	}
 

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/supposethread/SupposeThreadTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/supposethread/SupposeThreadTest.java
@@ -23,8 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.androidannotations.api.BackgroundExecutor;
 import org.androidannotations.test15.EmptyActivityWithoutLayout;
-import org.androidannotations.test15.ebean.BeanInjectedActivity;
-import org.androidannotations.test15.ebean.BeanInjectedActivity_;
 import org.androidannotations.test15.ebean.ThreadControlledBean;
 import org.androidannotations.test15.ebean.ThreadControlledBean_;
 import org.junit.Assert;

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/trace/TracedActivityTest.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/androidannotations/test15/trace/TracedActivityTest.java
@@ -38,9 +38,8 @@ public class TracedActivityTest {
 	private TracedActivity activity;
 
 	@Before
-	public void setup() {
-		activity = Robolectric.buildActivity(TracedActivity_.class).create()
-				.start().resume().get();
+	public void setUp() {
+		activity = Robolectric.buildActivity(TracedActivity_.class).create().start().resume().get();
 	}
 
 	@Test
@@ -117,8 +116,7 @@ public class TracedActivityTest {
 
 	@Test
 	public void noReturnIntentParam() {
-		activity.noReturnIntentParam(new Intent("TEST", 
-				Uri.parse("http://www.androidannotations.org")));
+		activity.noReturnIntentParam(new Intent("TEST", Uri.parse("http://www.androidannotations.org")));
 
 		assertTrue(logContains("Entering [void noReturnIntentParam(param = Intent{action=TEST, extras=Bundle[{}], data=http://www.androidannotations.org})]"));
 		assertTrue(logContains("Exiting [void noReturnIntentParam(Intent)], duration in ms: "));
@@ -148,8 +146,7 @@ public class TracedActivityTest {
 	}
 
 	public void intentReturnIntentParam() {
-		activity.intentReturnIntentParam(new Intent("TEST",
-				Uri.parse("http://www.androidannotations.org")));
+		activity.intentReturnIntentParam(new Intent("TEST", Uri.parse("http://www.androidannotations.org")));
 
 		assertTrue(logContains("Entering [java.lang.String intentReturnIntentParam(param = Intent{action=TEST, extras=Bundle[{}], data=http://www.androidannotations.org})]"));
 		assertTrue(logContains("Exiting [java.lang.String intentReturnIntentParam(Intent) returning: test], duration in ms: "));
@@ -157,7 +154,7 @@ public class TracedActivityTest {
 
 	/**
 	 * Check if a message has been logged
-	 * 
+	 *
 	 * @param msg
 	 * @return {@code true} if a log entry starting with {@code msg} exists
 	 */
@@ -165,8 +162,9 @@ public class TracedActivityTest {
 		List<LogItem> logs = ShadowLog.getLogs();
 		boolean found = false;
 		for (LogItem logItem : logs) {
-			if (logItem.msg.startsWith(msg))
+			if (logItem.msg.startsWith(msg)) {
 				found = true;
+			}
 		}
 		return found;
 	}

--- a/AndroidAnnotations/functional-test-1-5/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerWorkaround.java
+++ b/AndroidAnnotations/functional-test-1-5/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerWorkaround.java
@@ -15,6 +15,11 @@
  */
 package org.robolectric;
 
+import static org.fest.reflect.core.Reflection.constructor;
+import static org.fest.reflect.core.Reflection.field;
+import static org.fest.reflect.core.Reflection.method;
+import static org.fest.reflect.core.Reflection.type;
+
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
@@ -23,10 +28,7 @@ import java.util.Map;
 import org.fest.reflect.reference.TypeRef;
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
-import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
-
-import static org.fest.reflect.core.Reflection.*;
 
 public class ParameterizedRobolectricTestRunnerWorkaround extends Suite {
 
@@ -35,43 +37,42 @@ public class ParameterizedRobolectricTestRunnerWorkaround extends Suite {
 	private Class<?> testRunnerClass; // ParameterizedRobolectricTestRunner$TestClassRunnerForParameters.class
 	private RobolectricTestRunner testrunner;
 	private List<Runner> runners; // delegate.getChildren()
-	
-	public ParameterizedRobolectricTestRunnerWorkaround(Class<?> klass) throws Throwable {
-		super(klass, Collections.<Runner>emptyList());
-		
+
+	public ParameterizedRobolectricTestRunnerWorkaround(Class<?> klass) throws Exception {
+		super(klass, Collections.<Runner> emptyList());
+
 		testrunner = new ClassLoaderCreatorRobolectricTestRunner(klass);
-		
+
 		Config config = testrunner.getConfig(klass.getMethods()[0]);
-		
+
 		AndroidManifest manifest = testrunner.getAppManifest(config);
-		SdkEnvironment environment  = method("getEnvironment")
-				.withReturnType(SdkEnvironment.class).withParameterTypes(AndroidManifest.class, Config.class).in(testrunner).invoke(manifest, config);
-		
+		SdkEnvironment environment = method("getEnvironment").withReturnType(SdkEnvironment.class).withParameterTypes(AndroidManifest.class, Config.class).in(testrunner).invoke(manifest, config);
+
 		runnerClass = type(ParameterizedRobolectricTestRunner.class.getName()).withClassLoader(environment.getRobolectricClassLoader()).load();
 		testRunnerClass = type(runnerClass.getName() + "$TestClassRunnerForParameters").withClassLoader(environment.getRobolectricClassLoader()).load();
-		
+
 		Field lastTestRunnerClassField = field("lastTestRunnerClass").ofType(Class.class).in(RobolectricTestRunner.class).info();
 		lastTestRunnerClassField.setAccessible(true);
 		lastTestRunnerClassField.set(testrunner, testRunnerClass);
-		
-		delegate = constructor().withParameterTypes(Class.class).in(runnerClass)
-				.newInstance(type(klass.getName()).withClassLoader(environment.getRobolectricClassLoader()).load());
-		
+
+		delegate = constructor().withParameterTypes(Class.class).in(runnerClass).newInstance(type(klass.getName()).withClassLoader(environment.getRobolectricClassLoader()).load());
+
 		Field lastSdkEnvironmentField = field("lastSdkEnvironment").ofType(SdkEnvironment.class).in(RobolectricTestRunner.class).info();
 		lastSdkEnvironmentField.setAccessible(true);
-		
+
 		Field lastSdkConfigField = field("lastSdkConfig").ofType(SdkConfig.class).in(RobolectricTestRunner.class).info();
 		lastSdkConfigField.setAccessible(true);
-		
-		runners = method("getChildren").withReturnType(new TypeRef<List<Runner>>() {}) .in(delegate).invoke();
-		
+
+		runners = method("getChildren").withReturnType(new TypeRef<List<Runner>>() {
+		}).in(delegate).invoke();
+
 		for (Runner runner : runners) {
 			lastTestRunnerClassField.set(runner, testRunnerClass);
 			lastSdkEnvironmentField.set(runner, environment);
 			lastSdkConfigField.set(runner, environment.getSdkConfig());
 		}
 	}
-	
+
 	@Override
 	protected List<Runner> getChildren() {
 		return runners;
@@ -79,15 +80,14 @@ public class ParameterizedRobolectricTestRunnerWorkaround extends Suite {
 
 	private static class ClassLoaderCreatorRobolectricTestRunner extends RobolectricTestRunner {
 
-		public ClassLoaderCreatorRobolectricTestRunner(Class<?> testClass)
-				throws InitializationError, IllegalArgumentException, IllegalAccessException {
+		public ClassLoaderCreatorRobolectricTestRunner(Class<?> testClass) throws Exception {
 			super(testClass);
-			
-			Map<Class<? extends RobolectricTestRunner>, EnvHolder> envHoldersByTestRunner = 
-					field("envHoldersByTestRunner").ofType(new TypeRef<Map<Class<? extends RobolectricTestRunner>, EnvHolder>>() {}).in(this).get();
-			
+
+			Map<Class<? extends RobolectricTestRunner>, EnvHolder> envHoldersByTestRunner = field("envHoldersByTestRunner").ofType(new TypeRef<Map<Class<? extends RobolectricTestRunner>, EnvHolder>>() {
+			}).in(this).get();
+
 			EnvHolder envHolder = envHoldersByTestRunner.get(RobolectricTestRunner.class);
-			
+
 			if (envHolder != null) {
 				Field envHolderField = field("envHolder").ofType(EnvHolder.class).in(RobolectricTestRunner.class).info();
 				envHolderField.setAccessible(true);
@@ -96,7 +96,7 @@ public class ParameterizedRobolectricTestRunnerWorkaround extends Suite {
 				envHoldersByTestRunner.put(RobolectricTestRunner.class, envHolder);
 			}
 		}
-		
+
 		@Override
 		protected void validateConstructor(List<Throwable> errors) {
 			validateOnlyOneConstructor(errors);

--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -271,6 +271,7 @@
 						<suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
 						<consoleOutput>true</consoleOutput>
 						<linkXRef>false</linkXRef>
+						<includeTestSourceDirectory>true</includeTestSourceDirectory>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
I decided to change all `snake_case` test method names to `camelCase`, so we are conforming the Java style guide and also fit into the most of the test method's naming convention.
