### PR TITLE
Update github links to reflect the new organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - ./examples/gradle/gradlew assembleDebug --build-file examples/gradle/build.gradle
 
 after_success:
-  - if [[ $TRAVIS_REPO_SLUG == 'excilys/androidannotations' && $TRAVIS_BRANCH == 'develop' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_JDK_VERSION == 'oraclejdk7' ]]; then mvn -f AndroidAnnotations/pom.xml -DskipTests -Dquiet -s settings.xml deploy ; fi
+  - if [[ $TRAVIS_REPO_SLUG == 'androidannotations/androidannotations' && $TRAVIS_BRANCH == 'develop' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_JDK_VERSION == 'oraclejdk7' ]]; then mvn -f AndroidAnnotations/pom.xml -DskipTests -Dquiet -s settings.xml deploy ; fi
 
 notifications:
   webhooks:

--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/bundle/BundleHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/api/bundle/BundleHelper.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,7 +39,7 @@ public final class BundleHelper {
 	 * subclass arrays.
 	 * 
 	 * For more info, see <a
-	 * href="https://github.com/excilys/androidannotations/issues/1208">this</a>
+	 * href="https://github.com/androidannotations/androidannotations/issues/1208">this</a>
 	 * url.
 	 * 
 	 * @param bundle

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/ErrorHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/ErrorHelper.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -37,7 +38,7 @@ public class ErrorHelper {
 
 	public String getErrorMessage(ProcessingEnvironment processingEnv, ProcessingException e, String aaVersion) {
 		String errorMessage = "Unexpected error in AndroidAnnotations " + aaVersion + "!\n"
-				+ "You should check if there is already an issue about it on https://github.com/excilys/androidannotations/search?q=" + urlEncodedErrorMessage(e) + "&type=Issues\n"
+				+ "You should check if there is already an issue about it on https://github.com/androidannotations/androidannotations/search?q=" + urlEncodedErrorMessage(e) + "&type=Issues\n"
 				+ "If none exists, please open a new one with the following content and tell us if you can reproduce it or not. "
 				+ "Don't forget to give us as much information as you can (like parts of your code in failure).\n";
 		errorMessage += "Java version: " + getJavaCompilerVersion() + "\n";

--- a/AndroidAnnotations/androidannotations-roboguice/roboguice-api/src/main/java/org/androidannotations/roboguice/annotations/RoboGuice.java
+++ b/AndroidAnnotations/androidannotations-roboguice/roboguice-api/src/main/java/org/androidannotations/roboguice/annotations/RoboGuice.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -60,7 +61,7 @@ import java.lang.annotation.Target;
  * </blockquote>
  * 
  * @see <a
- *      href="https://github.com/excilys/androidannotations/wiki/RoboGuiceIntegration">RoboGuiceIntegration</a>
+ *      href="https://github.com/androidannotations/androidannotations/wiki/RoboGuiceIntegration">RoboGuiceIntegration</a>
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)

--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+    Copyright (C) 2016 the AndroidAnnotations project
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not
     use this file except in compliance with the License. You may obtain a copy of
@@ -406,9 +407,9 @@
 	</build>
 
 	<scm>
-		<connection>scm:git:git@github.com:excilys/androidannotations.git</connection>
-		<developerConnection>scm:git:git@github.com:excilys/androidannotations.git</developerConnection>
-		<url>https://github.com/excilys/androidannotations</url>
+		<connection>scm:git:git@github.com:androidannotations/androidannotations.git</connection>
+		<developerConnection>scm:git:git@github.com:androidannotations/androidannotations.git</developerConnection>
+		<url>https://github.com/androidannotations/androidannotations</url>
 		<tag>HEAD</tag>
 	</scm>
 

--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -316,6 +316,7 @@
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<configuration>
+					<skip>true</skip>
 					<header>${main.basedir}/src/etc/header.txt</header>
 					<excludes>
 						<exclude>.idea/**</exclude>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ### If you are opening an issue...
 
-...please read some [hints](https://github.com/excilys/androidannotations/wiki/HowToWriteAnIssue) about issues first.
+...please read some [hints](https://github.com/androidannotations/androidannotations/wiki/HowToWriteAnIssue) about issues first.
 
 ### If you want to create a pull request...
 
-...please read some information on [how to contribute code](https://github.com/excilys/androidannotations/wiki/HowToContributeCode).
+...please read some information on [how to contribute code](https://github.com/androidannotations/androidannotations/wiki/HowToContributeCode).
 
-### Either way, you could read about [contribution in general](https://github.com/excilys/androidannotations/wiki/Contributing).
+### Either way, you could read about [contribution in general](https://github.com/androidannotations/androidannotations/wiki/Contributing).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Fast Android Development. Easy maintenance.
 
-[![Android Annotations Logo](https://github.com/excilys/androidannotations/wiki/img/aa-logo.png)](https://github.com/excilys/androidannotations/wiki/Home) 
+[![Android Annotations Logo](https://github.com/androidannotations/androidannotations/wiki/img/aa-logo.png)](https://github.com/androidannotations/androidannotations/wiki/Home) 
 
 **AndroidAnnotations** is an Open Source framework that **speeds up** Android development.
 It takes care of the **plumbing**, and lets you concentrate on what's really important. By **simplifying** your code, it facilitates its **maintenance**.
 
-### [**Documentation**](https://github.com/excilys/androidannotations/wiki/Home)
+### [**Documentation**](https://github.com/androidannotations/androidannotations/wiki/Home)
 
-[![Build Status](https://travis-ci.org/excilys/androidannotations.svg?branch=develop)](https://travis-ci.org/excilys/androidannotations/builds) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-AndroidAnnotations-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/128)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/excilys/androidannotations?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build Status](https://travis-ci.org/androidannotations/androidannotations.svg?branch=develop)](https://travis-ci.org/androidannotations/androidannotations/builds) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-AndroidAnnotations-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/128)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/androidannotations/androidannotations?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
As we have moved form github.com/excilys to github.com/androidannotations this PR aims to update all related references in the codebase