### PR TITLE
Clarified javadocs in @SharedPrefs with backticks

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/SharedPrefHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/SharedPrefHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +36,7 @@ import org.androidannotations.api.sharedpreferences.IntPrefEditorField;
 import org.androidannotations.api.sharedpreferences.LongPrefEditorField;
 import org.androidannotations.api.sharedpreferences.SharedPreferencesHelper;
 import org.androidannotations.api.sharedpreferences.StringPrefEditorField;
+import org.androidannotations.api.sharedpreferences.StringPrefField;
 import org.androidannotations.api.sharedpreferences.StringSetPrefEditorField;
 import org.androidannotations.helper.CanonicalNameConstants;
 
@@ -118,8 +120,18 @@ public class SharedPrefHolder extends BaseGeneratedClassHolder {
 	public void createFieldMethod(Class<?> prefFieldHelperClass, IJExpression keyExpression, String fieldName, String fieldHelperMethodName, IJExpression defaultValue,
 			String docComment, String defaultValueStr) {
 		JMethod fieldMethod = generatedClass.method(PUBLIC, prefFieldHelperClass, fieldName);
+
 		if (defaultValueStr != null) {
-			fieldMethod.javadoc().append("<p><b>Defaults to</b>: " + defaultValueStr + "</p>\n");
+			boolean isStringPrefField = StringPrefField.class == prefFieldHelperClass;
+
+			final String defaultValueJavaDoc;
+			if (isStringPrefField) {
+				defaultValueJavaDoc = "\"" + defaultValueStr + "\"";
+			} else {
+				defaultValueJavaDoc = defaultValueStr;
+			}
+
+			fieldMethod.javadoc().append("<p><b>Defaults to</b>: " + defaultValueJavaDoc + "</p>\n");
 		}
 		codeModelHelper.addTrimmedDocComment(fieldMethod, docComment);
 		fieldMethod.body()._return(JExpr.invoke(fieldHelperMethodName).arg(keyExpression).arg(defaultValue));

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/GenerateJavaDocTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/GenerateJavaDocTest.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -95,4 +96,42 @@ public class GenerateJavaDocTest extends AAProcessorTestHelper {
 		assertGeneratedClassContains(generatedFile, fieldDoc);
 		assertGeneratedClassContains(generatedFile, editorDoc);
 	}
+
+	@Test
+	public void generateJavaDocForEmptySharedPrefStringFields() throws IOException {
+		CompileResult result = compileFiles(SharedPrefWithJavaDoc.class);
+		File generatedFile = toGeneratedFile(SharedPrefWithJavaDoc.class);
+
+		assertCompilationSuccessful(result);
+
+		// CHECKSTYLE:OFF
+		String[] fieldDoc = { //
+				"     * <p><b>Defaults to</b>: \"\"</p>", //
+				"     * ", //
+				"     */", //
+				"    public StringPrefField title() {", //
+		};
+		// CHECKSTYLE:ON
+		assertGeneratedClassContains(generatedFile, fieldDoc);
+	}
+
+
+	@Test
+	public void generateJavaDocForNonEmptySharedPrefStringFields() throws IOException {
+		CompileResult result = compileFiles(SharedPrefWithJavaDoc.class);
+		File generatedFile = toGeneratedFile(SharedPrefWithJavaDoc.class);
+
+		assertCompilationSuccessful(result);
+
+		// CHECKSTYLE:OFF
+		String[] fieldDoc = { //
+				"     * <p><b>Defaults to</b>: \"something\"</p>", //
+				"     * ", //
+				"     */", //
+				"    public StringPrefField something() {", //
+		};
+		// CHECKSTYLE:ON
+		assertGeneratedClassContains(generatedFile, fieldDoc);
+	}
+
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/SharedPrefWithJavaDoc.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/generation/SharedPrefWithJavaDoc.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,4 +39,9 @@ public interface SharedPrefWithJavaDoc {
 
 	@DefaultLong(42L)
 	long ageLong();
+
+	String title();
+
+	@DefaultString("something")
+	String something();
 }


### PR DESCRIPTION
```
Previously, "<p><b>Defaults to</b>: </p>" was generated for string fields with
an empty default value. This commit inserts back-ticks so that the default
value in the javadoc is easier to be identified:

 * "<p><b>Defaults to</b>: ""</p>" for empty default strings
 * "<p><b>Defaults to</b>: "value"</p>" for @DefaultString("value")
```

I had to wrap this in code tags because the b-tags made the message unreadable