### PR TITLE
Update licenses for new ownership

### DIFF
--- a/AndroidAnnotations/pom.xml
+++ b/AndroidAnnotations/pom.xml
@@ -316,11 +316,14 @@
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<configuration>
-					<skip>true</skip>
-					<header>${main.basedir}/src/etc/header.txt</header>
+					<header>${main.basedir}/src/etc/header_new.txt</header>
+					<validHeaders>
+						<validHeader>${main.basedir}/src/etc/header.txt</validHeader>
+						<validHeader>${main.basedir}/src/etc/header_both.txt</validHeader>
+					</validHeaders>
 					<excludes>
 						<exclude>.idea/**</exclude>
-						<exclude>src/etc/HOW-TO.txt</exclude>
+						<exclude>src/etc/header*.txt</exclude>
 						<exclude>LICENSE.txt</exclude>
 						<exclude>.gitignore</exclude>
 						<exclude>**/R.java</exclude>

--- a/AndroidAnnotations/src/etc/header_both.txt
+++ b/AndroidAnnotations/src/etc/header_both.txt
@@ -1,0 +1,16 @@
+Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+Copyright (C) 2016 the AndroidAnnotations project
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed To in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+
+

--- a/AndroidAnnotations/src/etc/header_new.txt
+++ b/AndroidAnnotations/src/etc/header_new.txt
@@ -1,0 +1,15 @@
+Copyright (C) 2016 the AndroidAnnotations project
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed To in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+
+


### PR DESCRIPTION
This does the following:

* `maven license:check` passes for all combinations
* `maven license:format` will add the license with only AA project as copyright holder (this should be fine, as mostly new files are formatted for license headers, existing files already have a header. New files should only have the AA project in the header).
* Adding the AA line to the header for changed files is still not enforced by the plugin, it must be enforced manually when reviewing PRs 😢 