### PR TITLE
Rename variables used for @Trace to avoid name collisions

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/TraceHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/TraceHandler.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,6 +22,7 @@ import static org.androidannotations.helper.AndroidConstants.LOG_INFO;
 import static org.androidannotations.helper.AndroidConstants.LOG_VERBOSE;
 import static org.androidannotations.helper.AndroidConstants.LOG_WARN;
 import static org.androidannotations.helper.LogHelper.trimLogTag;
+import static org.androidannotations.helper.ModelConstants.generationSuffix;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,7 +100,7 @@ public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 		logEnterInvoke.arg(getEnterMessage(method, executableElement));
 		thenBody.add(logEnterInvoke);
-		JVar startDeclaration = thenBody.decl(getCodeModel().LONG, "start", currentTimeInvoke);
+		JVar startDeclaration = thenBody.decl(getCodeModel().LONG, "traceStart" + generationSuffix(), currentTimeInvoke);
 
 		JTryBlock tryBlock;
 
@@ -108,7 +110,7 @@ public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
 			tryBlock.body().add(previousMethodBody);
 		} else {
 			JInvocation superCall = codeModelHelper.getSuperCall(holder, method);
-			result = thenBody.decl(getJClass(Object.class), "result", JExpr._null());
+			result = thenBody.decl(getJClass(Object.class), "traceResult" + generationSuffix(), JExpr._null());
 			tryBlock = thenBody._try();
 			tryBlock.body().assign(result, superCall);
 			tryBlock.body()._return(JExpr.cast(boxify(method.type()), result));
@@ -116,7 +118,7 @@ public class TraceHandler extends BaseAnnotationHandler<EComponentHolder> {
 
 		JBlock finallyBlock = tryBlock._finally();
 
-		JVar durationDeclaration = finallyBlock.decl(getCodeModel().LONG, "duration", currentTimeInvoke.minus(startDeclaration));
+		JVar durationDeclaration = finallyBlock.decl(getCodeModel().LONG, "traceDuration" + generationSuffix(), currentTimeInvoke.minus(startDeclaration));
 
 		JInvocation logExitInvoke = getClasses().LOG.staticInvoke(logMethodName);
 		logExitInvoke.arg(tag);


### PR DESCRIPTION
- prefix variables with trace
- postifx variables with underscore

see #1891 