### PR TITLE
Add name parameter to @SharedPref

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/sharedpreferences/SharedPref.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-api/src/main/java/org/androidannotations/annotations/sharedpreferences/SharedPref.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -105,6 +106,14 @@ public @interface SharedPref {
 	 * @return the scope of the preferences
 	 */
 	Scope value() default Scope.ACTIVITY;
+
+	/**
+	 * The name of the preferences. To be used with {@link Scope#ACTIVITY} or
+	 * {@link Scope#UNIQUE}. If empty the interface name is used.
+	 *
+	 * @return the name of the preferences
+	 */
+	String name() default "";
 
 	/**
 	 * The operating mode.

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SharedPrefHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/SharedPrefHandler.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,6 +24,7 @@ import static com.helger.jcodemodel.JMod.STATIC;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -143,6 +145,15 @@ public class SharedPrefHandler extends CoreBaseGeneratingAnnotationHandler<Share
 				}
 			}
 		}
+
+		SharedPref sharedPrefAnnotation = element.getAnnotation(SharedPref.class);
+		SharedPref.Scope scope = sharedPrefAnnotation.value();
+		String name = sharedPrefAnnotation.name();
+		boolean hasCustomName = !name.trim().isEmpty();
+		EnumSet<SharedPref.Scope> allowedScopes = EnumSet.of(SharedPref.Scope.ACTIVITY, SharedPref.Scope.UNIQUE);
+		if (hasCustomName && !allowedScopes.contains(scope)) {
+			validation.addError("SharedPref#name() is only supported for Scope.ACTIVITY and Scope.UNIQUE.");
+		}
 	}
 
 	@Override
@@ -154,9 +165,12 @@ public class SharedPrefHandler extends CoreBaseGeneratingAnnotationHandler<Share
 	private void generateConstructor(Element element, SharedPrefHolder holder) {
 		SharedPref sharedPrefAnnotation = element.getAnnotation(SharedPref.class);
 		SharedPref.Scope scope = sharedPrefAnnotation.value();
+		String name = sharedPrefAnnotation.name();
 		int mode = sharedPrefAnnotation.mode();
 
-		String interfaceSimpleName = element.getSimpleName().toString();
+		if (name.trim().isEmpty()) {
+			name = element.getSimpleName().toString();
+		}
 		JBlock constructorSuperBlock = holder.getConstructorSuperBlock();
 		JVar contextParam = holder.getConstructorContextParam();
 
@@ -174,14 +188,14 @@ public class SharedPrefHandler extends CoreBaseGeneratingAnnotationHandler<Share
 			constructorSuperBlock.invoke("super") //
 					.arg(contextParam.invoke("getSharedPreferences") //
 							.arg(invoke(getLocalClassName).arg(contextParam) //
-									.plus(lit("_" + interfaceSimpleName))) //
+									.plus(lit("_" + name))) //
 							.arg(lit(mode)));
 			break;
 		}
 		case UNIQUE: {
 			constructorSuperBlock.invoke("super") //
 					.arg(contextParam.invoke("getSharedPreferences") //
-							.arg(lit(interfaceSimpleName)) //
+							.arg(lit(name)) //
 							.arg(lit(mode)));
 			break;
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/ActivityInManifest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/ActivityInManifest.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2016 the AndroidAnnotations project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.sharedprefs;
+
+import org.androidannotations.annotations.EActivity;
+
+import android.app.Activity;
+
+@EActivity
+public class ActivityInManifest extends Activity {
+
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/PrefsCollection.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/PrefsCollection.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016 the AndroidAnnotations project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.sharedprefs;
+
+import org.androidannotations.annotations.EBean;
+import org.androidannotations.annotations.sharedpreferences.SharedPref;
+
+@EBean
+public class PrefsCollection {
+
+	@SharedPref(SharedPref.Scope.ACTIVITY)
+	public interface ActivityPrefs {
+
+	}
+
+	@SharedPref(value = SharedPref.Scope.ACTIVITY, name = "named_pref_activity")
+	public interface NamedActivityPrefs {
+
+	}
+
+	@SharedPref(SharedPref.Scope.UNIQUE)
+	public interface UniquePrefs {
+
+	}
+
+	@SharedPref(value = SharedPref.Scope.UNIQUE, name = "named_pref_unique")
+	public interface NamedUniquePrefs {
+
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/PrefsCollectionWithError.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/PrefsCollectionWithError.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2016 the AndroidAnnotations project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.sharedprefs;
+
+import org.androidannotations.annotations.EBean;
+import org.androidannotations.annotations.sharedpreferences.SharedPref;
+
+@EBean
+public class PrefsCollectionWithError {
+
+	@SharedPref(value = SharedPref.Scope.ACTIVITY_DEFAULT, name = "named_pref_activity_default")
+	public interface NamedActivityDefaultPrefs {
+
+	}
+
+	@SharedPref(value = SharedPref.Scope.APPLICATION_DEFAULT, name = "named_pref_application_default")
+	public interface NamedApplicationDefaultPrefs {
+
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/SharedPrefNamingTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/sharedprefs/SharedPrefNamingTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2016 the AndroidAnnotations project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed To in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.androidannotations.sharedprefs;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.androidannotations.internal.AndroidAnnotationProcessor;
+import org.androidannotations.testutils.AAProcessorTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SharedPrefNamingTest extends AAProcessorTestHelper {
+
+	@Before
+	public void setUp() {
+		addManifestProcessorParameter(ActivityInManifest.class);
+		addProcessor(AndroidAnnotationProcessor.class);
+		ensureOutputDirectoryIsEmpty();
+	}
+
+	@Test
+	public void testNamedPrefGeneration() throws IOException {
+		CompileResult result = compileFiles(PrefsCollection.class);
+		File generatedFile = toGeneratedFile(PrefsCollection.class);
+
+		assertCompilationSuccessful(result);
+
+		// CHECKSTYLE:OFF
+		String[] activityPref = { //
+				"        public ActivityPrefs_(Context context) {", //
+				"            super(context.getSharedPreferences((getLocalClassName(context)+\"_ActivityPrefs\"), 0));", //
+				"        }" //
+		};
+		String[] namedActivityPref = { //
+				"        public NamedActivityPrefs_(Context context) {", //
+				"            super(context.getSharedPreferences((getLocalClassName(context)+\"_named_pref_activity\"), 0));", //
+				"        }" //
+		};
+		String[] uniquePref = { //
+				"        public UniquePrefs_(Context context) {", //
+				"            super(context.getSharedPreferences(\"UniquePrefs\", 0));", //
+				"        }" //
+		};
+		String[] namedUniquePref = { //
+				"        public NamedUniquePrefs_(Context context) {", //
+				"            super(context.getSharedPreferences(\"named_pref_unique\", 0));", //
+				"        }" //
+		};
+		// CHECKSTYLE:ON
+		assertGeneratedClassContains(generatedFile, activityPref);
+		assertGeneratedClassContains(generatedFile, namedActivityPref);
+		assertGeneratedClassContains(generatedFile, uniquePref);
+		assertGeneratedClassContains(generatedFile, namedUniquePref);
+	}
+
+	@Test
+	public void testNamedPrefGenerationErrors() throws IOException {
+		CompileResult result = compileFiles(PrefsCollectionWithError.class);
+
+		assertCompilationError(result);
+
+		assertCompilationErrorOn(PrefsCollectionWithError.class, "@SharedPref(value = SharedPref.Scope.ACTIVITY_DEFAULT, name = \"named_pref_activity_default\")", result);
+		assertCompilationErrorOn(PrefsCollectionWithError.class, "@SharedPref(value = SharedPref.Scope.APPLICATION_DEFAULT, name = \"named_pref_application_default\")", result);
+	}
+}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/sharedprefs/AndroidManifest.xml
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/resources/org/androidannotations/sharedprefs/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (C) 2016 the AndroidAnnotations project
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed To in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.androidannotations.testprocessor"
+    android:versionCode="1"
+    android:versionName="1.0" >
+    
+    <application>
+    		<activity android:name="org.androidannotations.sharedprefs.ActivityInManifest_" />
+   	</application>
+
+</manifest>


### PR DESCRIPTION
This PR implements the feature request of https://github.com/androidannotations/androidannotations/issues/1675.

With this PR it is possible to provide a custom name for the preference file of a `@SharedPref` interface.