### PR TITLE
Support for RadioGroup OnCheckedChangeListener in @CheckedChange annotation

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -75,6 +75,7 @@ public final class CanonicalNameConstants {
 	public static final String TEXT_VIEW_ON_EDITOR_ACTION_LISTENER = "android.widget.TextView.OnEditorActionListener";
 	public static final String COMPOUND_BUTTON = "android.widget.CompoundButton";
 	public static final String COMPOUND_BUTTON_ON_CHECKED_CHANGE_LISTENER = "android.widget.CompoundButton.OnCheckedChangeListener";
+	public static final String RADIO_GROUP = "android.widget.RadioGroup";
 	public static final String VIEW = "android.view.View";
 	public static final String VIEW_ON_CLICK_LISTENER = "android.view.View.OnClickListener";
 	public static final String VIEW_ON_TOUCH_LISTENER = "android.view.View.OnTouchListener";

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CanonicalNameConstants.java
@@ -76,6 +76,7 @@ public final class CanonicalNameConstants {
 	public static final String COMPOUND_BUTTON = "android.widget.CompoundButton";
 	public static final String COMPOUND_BUTTON_ON_CHECKED_CHANGE_LISTENER = "android.widget.CompoundButton.OnCheckedChangeListener";
 	public static final String RADIO_GROUP = "android.widget.RadioGroup";
+	public static final String RADIO_GROUP_ON_CHECKED_CHANGE_LISTENER = "android.widget.RadioGroup.OnCheckedChangeListener";
 	public static final String VIEW = "android.view.View";
 	public static final String VIEW_ON_CLICK_LISTENER = "android.view.View.OnClickListener";
 	public static final String VIEW_ON_TOUCH_LISTENER = "android.view.View.OnTouchListener";

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/ValidatorParameterHelper.java
@@ -120,7 +120,7 @@ public class ValidatorParameterHelper {
 		}
 
 		public V extendsAnyOfTypes(String... types) {
-			return  param(new ExtendsAnyOfTypesParameterRequirement(types));
+			return param(new ExtendsAnyOfTypesParameterRequirement(types));
 		}
 
 		public V anyType() {
@@ -133,6 +133,10 @@ public class ValidatorParameterHelper {
 
 		public V primitiveOrWrapper(TypeKind primitive) {
 			return param(new PrimitiveOrWrapperParameterRequirement(primitive));
+		}
+
+		public V anyOfPrimitiveOrWrapper(TypeKind... primitives) {
+			return param(new AnyOfPrimitiveOrWrapperParameterRequirement(primitives));
 		}
 
 		public V anyOfTypes(String... types) {
@@ -168,7 +172,6 @@ public class ValidatorParameterHelper {
 		protected void invalidate(ExecutableElement element, ElementValidation validation) {
 			validation.addError("%s can only have the following parameters: " + createMessage(element));
 		}
-
 
 		protected String createMessage(ExecutableElement element) {
 			StringBuilder builder = new StringBuilder();
@@ -442,6 +445,62 @@ public class ValidatorParameterHelper {
 		}
 
 		private String getWrapperType() {
+			switch (type) {
+			case BOOLEAN:
+				return CanonicalNameConstants.BOOLEAN;
+			case INT:
+				return CanonicalNameConstants.INTEGER;
+			case BYTE:
+				return CanonicalNameConstants.BYTE;
+			case SHORT:
+				return CanonicalNameConstants.SHORT;
+			case LONG:
+				return CanonicalNameConstants.LONG;
+			case CHAR:
+				return CanonicalNameConstants.CHAR;
+			case FLOAT:
+				return CanonicalNameConstants.FLOAT;
+			case DOUBLE:
+				return CanonicalNameConstants.DOUBLE;
+			default:
+				throw new IllegalArgumentException("The TypeKind passed does not represent a primitive");
+			}
+		}
+	}
+
+	public class AnyOfPrimitiveOrWrapperParameterRequirement extends BaseParameterRequirement {
+
+		private List<TypeKind> types;
+
+		public AnyOfPrimitiveOrWrapperParameterRequirement(TypeKind... types) {
+			this.types = Arrays.asList(types);
+		}
+
+		@Override
+		protected String description() {
+			StringBuilder builder = new StringBuilder();
+			builder.append("Any of the primitives: [");
+			for (int i = 0; i < types.size() - 1; ++i) {
+				builder.append(getWrapperType(types.get(i))).append(", ");
+			}
+			builder.append(getWrapperType(types.get(types.size() - 1))).append(" ]");
+
+			return builder.toString();
+		}
+
+		@Override
+		public boolean isSatisfied(VariableElement parameter) {
+			TypeMirror elementType = parameter.asType();
+
+			for (TypeKind type : types) {
+				if (elementType.getKind() == type || elementType.toString().equals(getWrapperType(type))) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private String getWrapperType(TypeKind type) {
 			switch (type) {
 			case BOOLEAN:
 				return CanonicalNameConstants.BOOLEAN;

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CheckedChangeHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CheckedChangeHandler.java
@@ -50,9 +50,9 @@ public class CheckedChangeHandler extends AbstractViewListenerHandler {
 		ExecutableElement executableElement = (ExecutableElement) element;
 		validatorHelper.returnTypeIsVoid(executableElement, validation);
 
-		validatorHelper.param.anyOrder() //
-				.extendsType(CanonicalNameConstants.COMPOUND_BUTTON).optional() //
-				.primitiveOrWrapper(TypeKind.BOOLEAN).optional() //
+		validatorHelper.param.inOrder() //
+				.extendsAnyOfTypes(CanonicalNameConstants.COMPOUND_BUTTON, CanonicalNameConstants.RADIO_GROUP).optional() //
+				.anyOfPrimitiveOrWrapper(TypeKind.BOOLEAN, TypeKind.INT).optional() //
 				.validate(executableElement, validation);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CheckedChangeHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/CheckedChangeHandler.java
@@ -30,6 +30,7 @@ import org.androidannotations.helper.CanonicalNameConstants;
 import org.androidannotations.holder.EComponentWithViewSupportHolder;
 
 import com.helger.jcodemodel.AbstractJClass;
+import com.helger.jcodemodel.AbstractJType;
 import com.helger.jcodemodel.JBlock;
 import com.helger.jcodemodel.JDefinedClass;
 import com.helger.jcodemodel.JInvocation;
@@ -38,6 +39,8 @@ import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.JVar;
 
 public class CheckedChangeHandler extends AbstractViewListenerHandler {
+
+	private String viewElement;
 
 	public CheckedChangeHandler(AndroidAnnotationsEnvironment environment) {
 		super(CheckedChange.class, environment);
@@ -63,15 +66,25 @@ public class CheckedChangeHandler extends AbstractViewListenerHandler {
 
 	@Override
 	protected void processParameters(EComponentWithViewSupportHolder holder, JMethod listenerMethod, JInvocation call, List<? extends VariableElement> parameters) {
-		JVar btnParam = listenerMethod.param(getClasses().COMPOUND_BUTTON, "buttonView");
-		JVar isCheckedParam = listenerMethod.param(getCodeModel().BOOLEAN, "isChecked");
-
 		for (VariableElement parameter : parameters) {
-			String parameterType = parameter.asType().toString();
 			if (isTypeOrSubclass(CanonicalNameConstants.COMPOUND_BUTTON, parameter)) {
+				viewElement = CanonicalNameConstants.COMPOUND_BUTTON;
+				JVar btnParam = listenerMethod.param(getClasses().COMPOUND_BUTTON, "buttonView");
 				call.arg(castArgumentIfNecessary(holder, CanonicalNameConstants.COMPOUND_BUTTON, btnParam, parameter));
-			} else if (parameterType.equals(CanonicalNameConstants.BOOLEAN) || parameter.asType().getKind() == TypeKind.BOOLEAN) {
-				call.arg(isCheckedParam);
+				if (listenerMethod.hasSignature(new AbstractJType[] { getClasses().COMPOUND_BUTTON, getCodeModel().BOOLEAN })) {
+					JVar isCheckedParam = listenerMethod.param(getCodeModel().BOOLEAN, "isChecked");
+					call.arg(isCheckedParam);
+					break;
+				}
+			} else if (isTypeOrSubclass(CanonicalNameConstants.RADIO_GROUP, parameter)) {
+				viewElement = CanonicalNameConstants.RADIO_GROUP;
+				JVar radioGroup = listenerMethod.param(getClasses().RADIO_GROUP, "radioGroup");
+				call.arg(castArgumentIfNecessary(holder, CanonicalNameConstants.RADIO_GROUP, radioGroup, parameter));
+				if (listenerMethod.hasSignature(new AbstractJType[] { getClasses().RADIO_GROUP, getCodeModel().INT })) {
+					JVar checkedId = listenerMethod.param(getCodeModel().INT, "checkedId");
+					call.arg(checkedId);
+					break;
+				}
 			}
 		}
 	}
@@ -88,11 +101,17 @@ public class CheckedChangeHandler extends AbstractViewListenerHandler {
 
 	@Override
 	protected AbstractJClass getListenerClass(EComponentWithViewSupportHolder holder) {
+		if (CanonicalNameConstants.RADIO_GROUP.equals(viewElement)) {
+			return getClasses().RADIO_GROUP_ON_CHECKED_CHANGE_LISTENER;
+		}
 		return getClasses().COMPOUND_BUTTON_ON_CHECKED_CHANGE_LISTENER;
 	}
 
 	@Override
 	protected AbstractJClass getListenerTargetClass(EComponentWithViewSupportHolder holder) {
+		if (CanonicalNameConstants.RADIO_GROUP.equals(viewElement)) {
+			return getClasses().RADIO_GROUP;
+		}
 		return getClasses().COMPOUND_BUTTON;
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ProcessHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ProcessHolder.java
@@ -79,6 +79,8 @@ public class ProcessHolder {
 		public final AbstractJClass TEXT_VIEW_ON_EDITOR_ACTION_LISTENER = refClass(CanonicalNameConstants.TEXT_VIEW_ON_EDITOR_ACTION_LISTENER);
 		public final AbstractJClass COMPOUND_BUTTON = refClass(CanonicalNameConstants.COMPOUND_BUTTON);
 		public final AbstractJClass COMPOUND_BUTTON_ON_CHECKED_CHANGE_LISTENER = refClass(CanonicalNameConstants.COMPOUND_BUTTON_ON_CHECKED_CHANGE_LISTENER);
+		public final AbstractJClass RADIO_GROUP = refClass(CanonicalNameConstants.RADIO_GROUP);
+		public final AbstractJClass RADIO_GROUP_ON_CHECKED_CHANGE_LISTENER = refClass(CanonicalNameConstants.RADIO_GROUP_ON_CHECKED_CHANGE_LISTENER);
 		public final AbstractJClass VIEW = refClass(CanonicalNameConstants.VIEW);
 		public final AbstractJClass VIEW_ON_CLICK_LISTENER = refClass(CanonicalNameConstants.VIEW_ON_CLICK_LISTENER);
 		public final AbstractJClass VIEW_ON_TOUCH_LISTENER = refClass(CanonicalNameConstants.VIEW_ON_TOUCH_LISTENER);


### PR DESCRIPTION
According to the discussion with @WonderCsabo, I have implemented the logic to check if the method annotated with `@CheckedChange` has the first parameter of type `RadioGroup`, then the second parameter (if present) should be of type `int/Integer` to represent `checkedId` else if first parameter is a `CompoundButton`, then the second parameter (if present) should be of type `boolean/Boolean` to represent `isChecked`.