### PR TITLE
Default viewDestroyed_ to true

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/efragment/MyListFragmentTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations-test/src/test/java/org/androidannotations/test/efragment/MyListFragmentTest.java
@@ -49,11 +49,11 @@ public class MyListFragmentTest {
 	@Before
 	public void setUp() {
 		myListFragment = new MyListFragment_();
-		startFragment(myListFragment);
 	}
 
 	@Test
 	public void isItemClickAvailableFromListFragment() {
+		startFragment(myListFragment);
 		ListView listView = (ListView) myListFragment.findViewById(android.R.id.list);
 		long itemId = listView.getAdapter().getItemId(TESTED_CLICKED_INDEX);
 		View view = listView.getChildAt(TESTED_CLICKED_INDEX);
@@ -65,6 +65,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void notIgnoredMethodIsCalled() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.notIgnored();
 		assertTrue(myListFragment.didExecute);
@@ -72,6 +73,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void uithreadMethodIsCalled() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.uiThread();
 		assertTrue(myListFragment.didExecute);
@@ -79,6 +81,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void uithreadMethodIsCanceled() {
+		startFragment(myListFragment);
 		ShadowLooper.pauseMainLooper();
 		myListFragment.uiThreadWithId();
 		UiThreadExecutor.cancelAll("id");
@@ -88,6 +91,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void backgroundMethodIsCalled() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		runBackgroundsOnSameThread();
 		myListFragment.backgroundThread();
@@ -96,6 +100,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void ignoredWhenDetachedWorksForUithreadMethod() {
+		startFragment(myListFragment);
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -105,6 +110,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void ignoredWhenDetachedWorksForBackgroundMethod() {
+		startFragment(myListFragment);
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -115,6 +121,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void ignoredWhenDetachedWorksForIgnoredMethod() {
+		startFragment(myListFragment);
 		popBackStack();
 
 		assertFalse(myListFragment.didExecute);
@@ -123,7 +130,15 @@ public class MyListFragmentTest {
 	}
 
 	@Test
+	public void ignoredBeforeOnCreateView() {
+		assertFalse(myListFragment.didExecute);
+		myListFragment.ignoreWhenViewDestroyed();
+		assertFalse(myListFragment.didExecute);
+	}
+
+	@Test
 	public void notIgnoredAfterOnCreateView() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.onCreateView(null, null, null);
 		assertFalse(myListFragment.didExecute);
@@ -133,6 +148,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void ignoredWhenViewDestroyedForIgnoredMethod() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.onDestroyView();
 		myListFragment.ignoreWhenViewDestroyed();
@@ -141,6 +157,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void notIgnoredAfterFragmentRecreate() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.onDestroyView();
 		myListFragment.onCreateView(null, null, null);
@@ -150,6 +167,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void notIgnoredBeforeDetached() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.ignored();
 		assertTrue(myListFragment.didExecute);
@@ -157,6 +175,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void notIgnoredBeforeViewDestroyed() {
+		startFragment(myListFragment);
 		assertFalse(myListFragment.didExecute);
 		myListFragment.ignoreWhenViewDestroyed();
 		assertTrue(myListFragment.didExecute);
@@ -164,6 +183,7 @@ public class MyListFragmentTest {
 
 	@Test
 	public void layoutNotInjectedWithoutForce() {
+		startFragment(myListFragment);
 		View buttonInInjectedLayout = myListFragment.getView().findViewById(R.id.conventionButton);
 
 		assertThat(buttonInInjectedLayout).isNull();

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -221,7 +221,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	private void setViewDestroyedField() {
-		viewDestroyedField = generatedClass.field(PRIVATE | VOLATILE, getCodeModel().BOOLEAN, "viewDestroyed" + generationSuffix());
+		viewDestroyedField = generatedClass.field(PRIVATE | VOLATILE, getCodeModel().BOOLEAN, "viewDestroyed" + generationSuffix(), TRUE);
 		getSetContentViewBlock().assign(viewDestroyedField, FALSE);
 		getOnDestroyViewAfterSuperBlock().assign(viewDestroyedField, TRUE);
 	}


### PR DESCRIPTION
This avoids methods annotated with @IgnoreWhen(IgnoreWhen.State.VIEW_DESTROYED) to be called before the fragment has been created/recreated.

This PR fixes the feature request of #1942 