### PR TITLE
Fix lib manifest finding with Gradle plugin 2.3

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -189,7 +189,8 @@ public class AndroidManifestFinder {
 		Iterable<String> possibleLocations() {
 			String gradleVariant = matcher.group(2);
 
-			return Arrays.asList("build/intermediates/manifests/full" + gradleVariant, "build/intermediates/bundles" + gradleVariant);
+			return Arrays.asList("build/intermediates/manifests/full" + gradleVariant, "build/intermediates/bundles" + gradleVariant,
+					"build/intermediates/manifests/aapt" + gradleVariant);
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -55,6 +55,7 @@ public class AndroidManifestFinderTest {
 
 		Object[] gradleManifestFoundInManifests = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleManifestFoundInBundles = { GRADLE_GEN_FOLDER, "build/intermediates/bundles/debug", true };
+		Object[] gradleManifestFoundInManifestsAapt = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/aapt/debug", true };
 
 		Object[] mavenManifestFoundInTarget = { MAVEN_GEN_FOLDER, "target", true };
 		Object[] mavenManifestFoundInSrc = { MAVEN_GEN_FOLDER, "src/main", true };
@@ -70,7 +71,8 @@ public class AndroidManifestFinderTest {
 
 		Object[] noGeneratedFolderFound = { "", "", false };
 
-		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
+		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, gradleManifestFoundInManifestsAapt,
+				mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
 				gradleManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound, noGeneratedFolderFound);
 	}
 


### PR DESCRIPTION
The new Android Gradle Plugin changed the location of the generated
manifest for library projects. This commit adds the ability to find
the manifest in the new location.

 #1974