### PR TITLE
Trigger SNAPSHOT deployment for JDK8 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - ./examples/gradle/gradlew assembleDebug --build-file examples/gradle/build.gradle
 
 after_success:
-  - if [[ $TRAVIS_REPO_SLUG == 'androidannotations/androidannotations' && $TRAVIS_BRANCH == 'develop' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_JDK_VERSION == 'oraclejdk7' ]]; then cd $TRAVIS_BUILD_DIR/AndroidAnnotations && ./mvnw -DskipTests -Dquiet -s settings.xml deploy ; fi
+  - if [[ $TRAVIS_REPO_SLUG == 'androidannotations/androidannotations' && $TRAVIS_BRANCH == 'develop' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_JDK_VERSION == 'oraclejdk8' ]]; then cd $TRAVIS_BUILD_DIR/AndroidAnnotations && ./mvnw -DskipTests -Dquiet -s settings.xml deploy ; fi
 
 notifications:
   webhooks:


### PR DESCRIPTION
see https://github.com/androidannotations/androidannotations/issues/1979

With the removal of JDK7 from travis build SNAPSHOTS where no longer deployed as they where configured to run in the JDK7 build