### PR TITLE
Ignore null-Intents in EIntentService classes

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EIntentServiceHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EIntentServiceHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2017 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +16,7 @@
  */
 package org.androidannotations.holder;
 
+import static com.helger.jcodemodel.JExpr._null;
 import static com.helger.jcodemodel.JMod.PUBLIC;
 
 import javax.lang.model.element.TypeElement;
@@ -73,6 +75,9 @@ public class EIntentServiceHolder extends EServiceHolder {
 		onHandleIntentMethod.annotate(Override.class);
 		onHandleIntentBody = onHandleIntentMethod.body();
 		codeModelHelper.callSuperMethod(onHandleIntentMethod, this, onHandleIntentBody);
+
+		onHandleIntentBody._if(onHandleIntentIntent.eq(_null()))._then()._return();
+
 		JInvocation getActionInvocation = JExpr.invoke(onHandleIntentIntent, "getAction");
 		onHandleIntentIntentAction = onHandleIntentBody.decl(getClasses().STRING, "action", getActionInvocation);
 	}


### PR DESCRIPTION
This PR avoids potential NullPointerExceptions in IntentServices as `onHandleIntent` might be called with a null intent.

see #1499 