### PR TITLE
Support R2 class for resource values

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/Options.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/Options.java
@@ -41,6 +41,7 @@ public class Options {
 		addSupportedOption(AndroidManifestFinder.OPTION_MANIFEST);
 		addSupportedOption(AndroidManifestFinder.OPTION_LIBRARY);
 		addSupportedOption(ProjectRClassFinder.OPTION_RESOURCE_PACKAGE_NAME);
+		addSupportedOption(ProjectRClassFinder.OPTION_USE_R2);
 		addSupportedOption(ModelConstants.OPTION_CLASS_SUFFIX);
 		addSupportedOption(FileAppender.OPTION_LOG_FILE);
 		addSupportedOption(LoggerContext.OPTION_LOG_LEVEL);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/rclass/ProjectRClassFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/rclass/ProjectRClassFinder.java
@@ -29,6 +29,7 @@ import org.androidannotations.rclass.IRClass;
 public class ProjectRClassFinder {
 
 	public static final Option OPTION_RESOURCE_PACKAGE_NAME = new Option("resourcePackageName", null);
+	public static final Option OPTION_USE_R2 = new Option("useR2", "false");
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProjectRClassFinder.class);
 
@@ -40,7 +41,7 @@ public class ProjectRClassFinder {
 
 	public IRClass find(AndroidManifest manifest) throws RClassNotFoundException {
 		Elements elementUtils = environment.getProcessingEnvironment().getElementUtils();
-		String rClass = getRClassPackageName(manifest) + ".R";
+		String rClass = getRClassPackageName(manifest) + "." + getRClassSimpleName();
 		TypeElement rType = elementUtils.getTypeElement(rClass);
 
 		if (rType == null) {
@@ -59,5 +60,11 @@ public class ProjectRClassFinder {
 		} else {
 			return manifest.getApplicationPackage();
 		}
+	}
+
+	private String getRClassSimpleName() {
+		boolean useR2 = environment.getOptionBooleanValue(OPTION_USE_R2);
+
+		return useR2 ? "R2" : "R";
 	}
 }


### PR DESCRIPTION
This PR adds support to ButterKnife R2 generator plugin. Please note only the SNAPSHOT version of that plugin generates all types of resources. For rationale, see the commit message.