### PR TITLE
Use normal R class even when validating with R2

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/rclass/RInnerClass.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/rclass/RInnerClass.java
@@ -129,6 +129,10 @@ public class RInnerClass implements IRInnerClass {
 			String rClassQualifiedName = rInnerClassName.substring(0, innerClassSuffix);
 			String innerClassSimpleName = rInnerClassName.substring(innerClassSuffix + 1);
 
+			if (rClassQualifiedName.endsWith("R2")) {
+				rClassQualifiedName = rClassQualifiedName.substring(0, rClassQualifiedName.length() - 1);
+			}
+
 			JDirectClass rClass = (JDirectClass) environment.getJClass(rClassQualifiedName);
 
 			AbstractJClass innerClass = null;


### PR DESCRIPTION
The final resource values will not be the same as the compile-time values,
so we have to use the R class in the generated code, even if the user set
to use the R2 class in annotation parameters.

Follow-up fix for:
https://github.com/androidannotations/androidannotations/pull/2022