### PR TITLE
Update AndroidManifestFinder for Gradle builds with kapt

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -34,7 +34,9 @@ import org.junit.runners.Parameterized;
 public class AndroidManifestFinderTest {
 
 	private static final String GRADLE_GEN_FOLDER = "build/generated/source/apt/debug";
+	private static final String GRADLE_FLAVOR_GEN_FOLDER = "build/generated/source/apt/flavor/debug";
 	private static final String GRADLE_KOTLIN_GEN_FOLDER = "build/generated/source/kapt/debug";
+	private static final String GRADLE_KOTLIN_FLAVOR_GEN_FOLDER = "build/generated/source/kapt/flavorDebug";
 
 	private static final String MAVEN_GEN_FOLDER = "target/generated-sources/annotations";
 
@@ -58,10 +60,16 @@ public class AndroidManifestFinderTest {
 		Object[] gradleManifestFoundInManifests = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleManifestFoundInBundles = { GRADLE_GEN_FOLDER, "build/intermediates/bundles/debug", true };
 		Object[] gradleManifestFoundInManifestsAapt = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/aapt/debug", true };
+		Object[] gradleManifestFoundInManifestsWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug", true };
+		Object[] gradleManifestFoundInBundlesWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/bundles/flavor/debug", true };
+		Object[] gradleManifestFoundInManifestsAaptWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/aapt/flavor/debug", true };
 
 		Object[] gradleKotlinManifestFoundInManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleKotlinManifestFoundInBundles = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/bundles/debug", true };
 		Object[] gradleKotlinManifestFoundInManifestsAapt = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/aapt/debug", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug", true };
+		Object[] gradleKotlinManifestFoundInBundlesWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/bundles/flavor/debug", true };
+		Object[] gradleKotlinManifestFoundInManifestsAaptWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/aapt/flavor/debug", true };
 
 		Object[] mavenManifestFoundInTarget = { MAVEN_GEN_FOLDER, "target", true };
 		Object[] mavenManifestFoundInSrc = { MAVEN_GEN_FOLDER, "src/main", true };
@@ -80,7 +88,9 @@ public class AndroidManifestFinderTest {
 		Object[] noGeneratedFolderFound = { "", "", false };
 
 		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, gradleManifestFoundInManifestsAapt,
+				gradleManifestFoundInManifestsWithFlavor, gradleManifestFoundInBundlesWithFlavor, gradleManifestFoundInManifestsAaptWithFlavor,
 				gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt,
+				gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor,
 				mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
 				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound,
 				noGeneratedFolderFound);


### PR DESCRIPTION
This should fix https://github.com/androidannotations/androidannotations/issues/2028

@WonderCsabo  @ahornerr could you test this?