### PR TITLE
Update Manifest finder for apk splits

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -63,6 +63,12 @@ public class AndroidManifestFinderTest {
 		Object[] gradleManifestFoundInManifestsWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug", true };
 		Object[] gradleManifestFoundInBundlesWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/bundles/flavor/debug", true };
 		Object[] gradleManifestFoundInManifestsAaptWithFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/aapt/flavor/debug", true };
+		Object[] gradleManifestFoundInManifestsWithAbiSplit = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86", true };
+		Object[] gradleManifestFoundInManifestsWithAbiSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86", true };
+		Object[] gradleManifestFoundInManifestsWithDensitySplit = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug/hdpi", true };
+		Object[] gradleManifestFoundInManifestsWithDensitySplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/hdpi", true };
+		Object[] gradleManifestFoundInManifestsWithBothSplit = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86/hdpi", true };
+		Object[] gradleManifestFoundInManifestsWithBothSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86/hdpi", true };
 
 		Object[] gradleKotlinManifestFoundInManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleKotlinManifestFoundInBundles = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/bundles/debug", true };
@@ -70,6 +76,12 @@ public class AndroidManifestFinderTest {
 		Object[] gradleKotlinManifestFoundInManifestsWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug", true };
 		Object[] gradleKotlinManifestFoundInBundlesWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/bundles/flavor/debug", true };
 		Object[] gradleKotlinManifestFoundInManifestsAaptWithFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/aapt/flavor/debug", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithAbiSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithDensitySplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug/hdpi", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/hdpi", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithBothSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86/hdpi", true };
+		Object[] gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86/hdpi", true };
 
 		Object[] mavenManifestFoundInTarget = { MAVEN_GEN_FOLDER, "target", true };
 		Object[] mavenManifestFoundInSrc = { MAVEN_GEN_FOLDER, "src/main", true };
@@ -89,8 +101,14 @@ public class AndroidManifestFinderTest {
 
 		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, gradleManifestFoundInManifestsAapt,
 				gradleManifestFoundInManifestsWithFlavor, gradleManifestFoundInBundlesWithFlavor, gradleManifestFoundInManifestsAaptWithFlavor,
+				gradleManifestFoundInManifestsWithAbiSplit, gradleManifestFoundInManifestsWithAbiSplitAndFlavor,
+				gradleManifestFoundInManifestsWithDensitySplit, gradleManifestFoundInManifestsWithDensitySplitAndFlavor,
+				gradleManifestFoundInManifestsWithBothSplit, gradleManifestFoundInManifestsWithBothSplitAndFlavor,
 				gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt,
 				gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor,
+				gradleKotlinManifestFoundInManifestsWithAbiSplit, gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor,
+				gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor,
+				gradleKotlinManifestFoundInManifestsWithBothSplit, gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor,
 				mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
 				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound,
 				noGeneratedFolderFound);


### PR DESCRIPTION
This PR is aimed to fix #2034 and allow android annotations to work in projects that use apk splits.