### PR TITLE
Fix IllegalStateException for @OrmLiteDao in view

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -54,8 +54,8 @@ import com.helger.jcodemodel.JMethod;
 import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.JVar;
 
-public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration,
-		HasPreferenceHeaders {
+public class EActivityHolder extends EComponentWithViewSupportHolder implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasActivityLifecycleMethods,
+		HasReceiverRegistration, HasPreferenceHeaders {
 
 	private ActivityIntentBuilder intentBuilder;
 	private JMethod onCreate;
@@ -726,15 +726,14 @@ public class EActivityHolder extends EComponentWithViewSupportHolder implements 
 		return onPauseAfterSuperBlock;
 	}
 
-
 	@Override
-	public JBlock getOnAttachAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnAttachAfterSuperBlock();
+	public JBlock getStartLifecycleAfterSuperBlock() {
+		return getOnCreateAfterSuperBlock();
 	}
 
 	@Override
-	public JBlock getOnDetachBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnDetachBeforeSuperBlock();
+	public JBlock getEndLifecycleBeforeSuperBlock() {
+		return getOnDestroyAfterSuperBlock();
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -51,7 +51,8 @@ import com.helger.jcodemodel.JMethod;
 import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.JVar;
 
-public class EFragmentHolder extends EComponentWithViewSupportHolder implements HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasReceiverRegistration, HasPreferences {
+public class EFragmentHolder extends EComponentWithViewSupportHolder implements HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasActivityLifecycleMethods,
+		HasReceiverRegistration, HasPreferences {
 
 	private JFieldVar contentView;
 	private JFieldVar viewDestroyedField;
@@ -487,6 +488,16 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 	}
 
 	@Override
+	public JBlock getStartLifecycleAfterSuperBlock() {
+		return getOnCreateAfterSuperBlock();
+	}
+
+	@Override
+	public JBlock getEndLifecycleBeforeSuperBlock() {
+		return getOnDestroyBeforeSuperBlock();
+	}
+
+	@Override
 	public JBlock getOnCreateAfterSuperBlock() {
 		if (onCreateAfterSuperBlock == null) {
 			setOnCreate();
@@ -534,7 +545,6 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		return onPauseBeforeSuperBlock;
 	}
 
-	@Override
 	public JBlock getOnAttachAfterSuperBlock() {
 		if (onAttachAfterSuperBlock == null) {
 			setOnAttach();
@@ -542,7 +552,6 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder implements 
 		return onAttachAfterSuperBlock;
 	}
 
-	@Override
 	public JBlock getOnDetachBeforeSuperBlock() {
 		if (onDetachBeforeSuperBlock == null) {
 			setOnDetach();

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2017 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -39,6 +40,7 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 	private ServiceIntentBuilder intentBuilder;
 	private JDefinedClass intentBuilderClass;
 	private ReceiverRegistrationDelegate<EServiceHolder> receiverRegistrationDelegate;
+	private JBlock onCreateAfterSuperBlock;
 	private JBlock onDestroyBeforeSuperBlock;
 
 	public EServiceHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement, AndroidManifest androidManifest) throws Exception {
@@ -70,6 +72,7 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 		JBlock onCreateBody = onCreate.body();
 		onCreateBody.invoke(getInit());
 		onCreateBody.invoke(JExpr._super(), onCreate);
+		onCreateAfterSuperBlock = onCreateBody.blockVirtual();
 	}
 
 	private void setOnDestroy() {
@@ -101,45 +104,16 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 	}
 
 	@Override
-	public JBlock getOnCreateAfterSuperBlock() {
-		return getInitBody();
+	public JBlock getStartLifecycleAfterSuperBlock() {
+		return onCreateAfterSuperBlock;
 	}
 
 	@Override
-	public JBlock getOnDestroyBeforeSuperBlock() {
+	public JBlock getEndLifecycleBeforeSuperBlock() {
 		if (onDestroyBeforeSuperBlock == null) {
 			setOnDestroy();
 		}
+
 		return onDestroyBeforeSuperBlock;
-	}
-
-	@Override
-	public JBlock getOnStartAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnStartAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnStopBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnStopBeforeSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnResumeAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnResumeAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnPauseBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnPauseBeforeSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnAttachAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnAttachAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnDetachBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnDetachBeforeSuperBlock();
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
@@ -169,42 +169,12 @@ public class EViewHolder extends EComponentWithViewSupportHolder implements HasI
 	}
 
 	@Override
-	public JBlock getOnCreateAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnCreateAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnDestroyBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnDestroyBeforeSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnStartAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnStartAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnStopBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnStopBeforeSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnResumeAfterSuperBlock() {
-		return receiverRegistrationDelegate.getOnResumeAfterSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnPauseBeforeSuperBlock() {
-		return receiverRegistrationDelegate.getOnPauseBeforeSuperBlock();
-	}
-
-	@Override
-	public JBlock getOnAttachAfterSuperBlock() {
+	public JBlock getStartLifecycleAfterSuperBlock() {
 		return getOnAttachedToWindowAfterSuperBlock();
 	}
 
 	@Override
-	public JBlock getOnDetachBeforeSuperBlock() {
+	public JBlock getEndLifecycleBeforeSuperBlock() {
 		return getOnDetachedToWindowBeforeSuperBlock();
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasActivityLifecycleMethods.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasActivityLifecycleMethods.java
@@ -16,17 +16,16 @@
  */
 package org.androidannotations.holder;
 
-import org.androidannotations.holder.ReceiverRegistrationDelegate.IntentFilterData;
-
-import com.helger.jcodemodel.IJExpression;
 import com.helger.jcodemodel.JBlock;
-import com.helger.jcodemodel.JFieldVar;
 
-public interface HasReceiverRegistration extends HasSimpleLifecycleMethods {
+public interface HasActivityLifecycleMethods extends GeneratedClassHolder {
 
-	IJExpression getContextRef();
+	JBlock getOnCreateAfterSuperBlock();
+	JBlock getOnDestroyBeforeSuperBlock();
 
-	JFieldVar getIntentFilterField(IntentFilterData intentFilterData);
+	JBlock getOnStartAfterSuperBlock();
+	JBlock getOnStopBeforeSuperBlock();
 
-	JBlock getIntentFilterInitializationBlock(IntentFilterData intentFilterData);
+	JBlock getOnResumeAfterSuperBlock();
+	JBlock getOnPauseBeforeSuperBlock();
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasSimpleLifecycleMethods.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/HasSimpleLifecycleMethods.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2017 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,17 +17,8 @@ package org.androidannotations.holder;
 
 import com.helger.jcodemodel.JBlock;
 
-public interface HasLifecycleMethods extends GeneratedClassHolder {
+public interface HasSimpleLifecycleMethods extends GeneratedClassHolder {
 
-	JBlock getOnCreateAfterSuperBlock();
-	JBlock getOnDestroyBeforeSuperBlock();
-
-	JBlock getOnStartAfterSuperBlock();
-	JBlock getOnStopBeforeSuperBlock();
-
-	JBlock getOnResumeAfterSuperBlock();
-	JBlock getOnPauseBeforeSuperBlock();
-
-	JBlock getOnAttachAfterSuperBlock();
-	JBlock getOnDetachBeforeSuperBlock();
+	JBlock getStartLifecycleAfterSuperBlock();
+	JBlock getEndLifecycleBeforeSuperBlock();
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/ReceiverRegistrationDelegate.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/ReceiverRegistrationDelegate.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2017 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,7 +36,6 @@ import com.helger.jcodemodel.JFieldVar;
 public class ReceiverRegistrationDelegate<T extends EComponentHolder & HasReceiverRegistration> extends GeneratedClassHolderDelegate<T> {
 
 	private Map<IntentFilterData, JFieldVar> intentFilterFields = new HashMap<>();
-	private IllegalStateException illegalStateException = new IllegalStateException("This shouldn't happen unless the validation is bad");
 
 	public ReceiverRegistrationDelegate(T holder) {
 		super(holder);
@@ -64,38 +64,6 @@ public class ReceiverRegistrationDelegate<T extends EComponentHolder & HasReceiv
 		}
 
 		return intentFilterField;
-	}
-
-	public JBlock getOnStartAfterSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnStopBeforeSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnPauseBeforeSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnAttachAfterSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnDetachBeforeSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnResumeAfterSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnCreateAfterSuperBlock() {
-		throw illegalStateException;
-	}
-
-	public JBlock getOnDestroyBeforeSuperBlock() {
-		throw illegalStateException;
 	}
 
 	public static class IntentFilterData {

--- a/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/holder/OrmLiteHolder.java
+++ b/AndroidAnnotations/androidannotations-ormlite/ormlite/src/main/java/org/androidannotations/ormlite/holder/OrmLiteHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2017 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +27,7 @@ import javax.lang.model.type.TypeMirror;
 import org.androidannotations.helper.CaseHelper;
 import org.androidannotations.helper.ModelConstants;
 import org.androidannotations.holder.EComponentHolder;
-import org.androidannotations.holder.HasLifecycleMethods;
+import org.androidannotations.holder.HasSimpleLifecycleMethods;
 import org.androidannotations.ormlite.helper.OrmLiteClasses;
 import org.androidannotations.plugin.PluginClassHolder;
 
@@ -47,7 +48,7 @@ public class OrmLiteHolder extends PluginClassHolder<EComponentHolder> {
 		JFieldVar databaseHelperRef = databaseHelperRefs.get(databaseHelperTypeMirror);
 		if (databaseHelperRef == null) {
 			databaseHelperRef = setDatabaseHelperRef(databaseHelperTypeMirror);
-			injectReleaseInOnDestroy(databaseHelperRef);
+			injectReleaseAtEndLifecycle(databaseHelperRef);
 		}
 		return databaseHelperRef;
 	}
@@ -65,12 +66,12 @@ public class OrmLiteHolder extends PluginClassHolder<EComponentHolder> {
 		return databaseHelperRef;
 	}
 
-	private void injectReleaseInOnDestroy(JFieldVar databaseHelperRef) {
-		if (holder() instanceof HasLifecycleMethods) {
-			JBlock destroyBody = ((HasLifecycleMethods) holder()).getOnDestroyBeforeSuperBlock();
+	private void injectReleaseAtEndLifecycle(JFieldVar databaseHelperRef) {
+		if (holder() instanceof HasSimpleLifecycleMethods) {
+			JBlock endLifecycleBody = ((HasSimpleLifecycleMethods) holder()).getEndLifecycleBeforeSuperBlock();
 
-			destroyBody.staticInvoke(getJClass(OrmLiteClasses.OPEN_HELPER_MANAGER), "releaseHelper");
-			destroyBody.assign(databaseHelperRef, _null());
+			endLifecycleBody.staticInvoke(getJClass(OrmLiteClasses.OPEN_HELPER_MANAGER), "releaseHelper");
+			endLifecycleBody.assign(databaseHelperRef, _null());
 		}
 	}
 


### PR DESCRIPTION
#2048

This commit contains a bigger refactor as well: the previous
implementation contained HasLifecycleMethods interface, which was
implemented by most all the components, even if they do not have
the specific methods. This is now changed.