### PR TITLE
Fix manifest finder for Android Studio 3.2

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CaseHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/CaseHelper.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2018 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -68,6 +69,15 @@ public final class CaseHelper {
 			return string.toLowerCase();
 		}
 		String first = string.substring(0, 1).toLowerCase();
+		String end = string.substring(1, string.length());
+		return first + end;
+	}
+
+	public static String upperCaseFirst(String string) {
+		if (string.length() < 2) {
+			return string.toUpperCase();
+		}
+		String first = string.substring(0, 1).toUpperCase();
 		String end = string.substring(1, string.length());
 		return first + end;
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -16,6 +16,7 @@
  */
 package org.androidannotations.internal.helper;
 
+import static org.androidannotations.helper.CaseHelper.upperCaseFirst;
 import static org.androidannotations.helper.ModelConstants.classSuffix;
 
 import java.io.File;
@@ -184,6 +185,8 @@ public class AndroidManifestFinder {
 		private static final List<String> SUPPORTED_ABI_SPLITS = Arrays.asList("arm64-v8a", "armeabi", "armeabi-v7a", "mips", "mips64", "x86", "x86_64");
 		private static final List<String> SUPPORTED_DENSITY_SPLITS = Arrays.asList("hdpi", "ldpi", "mdpi", "xhdpi", "xxhdpi", "xxxhdpi");
 
+		private static final String BUILD_TOOLS_V32_MANIFEST_PATH = "build/intermediates/merged_manifests";
+
 		GradleAndroidManifestFinderStrategy(String sourceFolder) {
 			super("Gradle", GRADLE_GEN_FOLDER, sourceFolder);
 		}
@@ -197,11 +200,42 @@ public class AndroidManifestFinder {
 
 			ArrayList<String> possibleLocations = new ArrayList<>();
 
+			findPossibleLocationsV32(path, variantPart, possibleLocations);
 			for (String directory : Arrays.asList("build/intermediates/manifests/full", "build/intermediates/bundles", "build/intermediates/manifests/aapt")) {
 				findPossibleLocations(path, directory, variantPart, possibleLocations);
 			}
 
 			return possibleLocations;
+		}
+
+		private void findPossibleLocationsV32(String basePath, String variantPart, List<String> possibleLocations) {
+			String[] directories = new File(basePath + BUILD_TOOLS_V32_MANIFEST_PATH).list();
+
+			if (directories == null) {
+				return;
+			}
+
+			if (variantPart.startsWith("/") || variantPart.startsWith("\\")) {
+				variantPart = variantPart.substring(1);
+			}
+
+			String[] variantParts = variantPart.split("[/\\\\]");
+			if (variantParts.length > 1) {
+				StringBuilder sb = new StringBuilder(variantParts[0]);
+				for (int i = 1; i < variantParts.length; i++) {
+					String part = variantParts[i];
+					sb.append(upperCaseFirst(part));
+				}
+				variantPart = sb.toString();
+			}
+
+			String processManifest = "process" + upperCaseFirst(variantPart) + "Manifest";
+			String possibleLocation = BUILD_TOOLS_V32_MANIFEST_PATH + "/" + variantPart + "/" + processManifest + "/merged";
+			File variantDir = new File(basePath + possibleLocation);
+			if (variantDir.isDirectory()) {
+				possibleLocations.add(possibleLocation);
+				addPossibleSplitLocations(basePath, possibleLocation, possibleLocations);
+			}
 		}
 
 		private void findPossibleLocations(String basePath, String targetPath, String variantPart, List<String> possibleLocations) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -57,6 +57,7 @@ public class AndroidManifestFinderTest {
 	@Parameterized.Parameters(name = "genFolderPath = {0}, manifestFolderPath = {1}, shouldFind = {2}")
 	public static Iterable<Object[]> createTestData() {
 
+		// CHECKSTYLE:OFF
 		Object[] gradleManifestFoundInManifests = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleManifestFoundInBundles = { GRADLE_GEN_FOLDER, "build/intermediates/bundles/debug", true };
 		Object[] gradleManifestFoundInManifestsAapt = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/aapt/debug", true };
@@ -69,6 +70,16 @@ public class AndroidManifestFinderTest {
 		Object[] gradleManifestFoundInManifestsWithDensitySplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/hdpi", true };
 		Object[] gradleManifestFoundInManifestsWithBothSplit = { GRADLE_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86/hdpi", true };
 		Object[] gradleManifestFoundInManifestsWithBothSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifests = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplit = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86",
+				true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplit = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/hdpi",
+				true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplit = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86/hdpi",
+				true };
 
 		Object[] gradleKotlinManifestFoundInManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleKotlinManifestFoundInBundles = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/bundles/debug", true };
@@ -82,6 +93,17 @@ public class AndroidManifestFinderTest {
 		Object[] gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/hdpi", true };
 		Object[] gradleKotlinManifestFoundInManifestsWithBothSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug/x86/hdpi", true };
 		Object[] gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/manifests/full/flavor/debug/x86/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithAbiSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86",
+				true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithDensitySplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER,
+				"build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER,
+				"build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86/hdpi", true };
+		// CHECKSTYLE:ON
 
 		Object[] mavenManifestFoundInTarget = { MAVEN_GEN_FOLDER, "target", true };
 		Object[] mavenManifestFoundInSrc = { MAVEN_GEN_FOLDER, "src/main", true };
@@ -99,19 +121,20 @@ public class AndroidManifestFinderTest {
 
 		Object[] noGeneratedFolderFound = { "", "", false };
 
-		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, gradleManifestFoundInManifestsAapt,
-				gradleManifestFoundInManifestsWithFlavor, gradleManifestFoundInBundlesWithFlavor, gradleManifestFoundInManifestsAaptWithFlavor,
-				gradleManifestFoundInManifestsWithAbiSplit, gradleManifestFoundInManifestsWithAbiSplitAndFlavor,
-				gradleManifestFoundInManifestsWithDensitySplit, gradleManifestFoundInManifestsWithDensitySplitAndFlavor,
-				gradleManifestFoundInManifestsWithBothSplit, gradleManifestFoundInManifestsWithBothSplitAndFlavor,
-				gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt,
-				gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor,
-				gradleKotlinManifestFoundInManifestsWithAbiSplit, gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor,
-				gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor,
-				gradleKotlinManifestFoundInManifestsWithBothSplit, gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor,
-				mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
-				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound,
-				noGeneratedFolderFound);
+		return Arrays.asList(gradleManifestFoundInManifests, gradleManifestFoundInBundles, gradleManifestFoundInManifestsAapt, gradleManifestFoundInManifestsWithFlavor,
+				gradleManifestFoundInBundlesWithFlavor, gradleManifestFoundInManifestsAaptWithFlavor, gradleManifestFoundInManifestsWithAbiSplit, gradleManifestFoundInManifestsWithAbiSplitAndFlavor,
+				gradleManifestFoundInManifestsWithDensitySplit, gradleManifestFoundInManifestsWithDensitySplitAndFlavor, gradleManifestFoundInManifestsWithBothSplit,
+				gradleManifestFoundInManifestsWithBothSplitAndFlavor, gradleManifestFoundInMergedManifests, gradleManifestFoundInMergedManifestsWithAbiSplit,
+				gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleManifestFoundInMergedManifestsWithDensitySplit, gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavor,
+				gradleManifestFoundInMergedManifestsWithBothSplit, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles,
+				gradleKotlinManifestFoundInManifestsAapt, gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor,
+				gradleKotlinManifestFoundInManifestsAaptWithFlavor, gradleKotlinManifestFoundInManifestsWithAbiSplit, gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor,
+				gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInManifestsWithBothSplit,
+				gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifests, gradleKotlinManifestFoundInMergedManifestsWithAbiSplit,
+				gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithDensitySplit,
+				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithBothSplit,
+				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor, mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
+				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound, noGeneratedFolderFound);
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds support for new Manifest locations for the Android Studio 3.2 canary builds.