### PR TITLE
Fix logging and prevent similar issues

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/AndroidAnnotationProcessor.java
@@ -91,7 +91,7 @@ public class AndroidAnnotationProcessor extends AbstractProcessor {
 			plugins.add(0, corePlugin);
 			androidAnnotationsEnv.setPlugins(plugins);
 		} catch (Exception e) {
-			LOGGER.error("Can't load plugins", e);
+			LOGGER.error(e, "Can't load plugins");
 		}
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/AndroidAnnotationProcessor.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/AndroidAnnotationProcessor.java
@@ -246,7 +246,7 @@ public class AndroidAnnotationProcessor extends AbstractProcessor {
 		Iterator<? extends TypeElement> iterator = annotations.iterator();
 		if (iterator.hasNext()) {
 			Element element = roundEnv.getElementsAnnotatedWith(iterator.next()).iterator().next();
-			LOGGER.error("Something went wrong: {}", element, errorMessage);
+			LOGGER.error(element, "Something went wrong: {}", errorMessage);
 		} else {
 			LOGGER.error("Something went wrong: {}", errorMessage);
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/generation/SourceCodeWriter.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/generation/SourceCodeWriter.java
@@ -70,7 +70,7 @@ public class SourceCodeWriter extends AbstractCodeWriter {
 
 			return sourceFile.openOutputStream();
 		} catch (FilerException e) {
-			LOGGER.error("Could not generate source file for {}", qualifiedClassName, e.getMessage());
+			LOGGER.error("Could not generate source file for {} due to error: {}", qualifiedClassName, e.getMessage());
 			/*
 			 * This exception is expected, when some files are created twice. We
 			 * cannot delete existing files, unless using a dirty hack. Files a

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelProcessor.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelProcessor.java
@@ -197,7 +197,7 @@ public class ModelProcessor {
 							if (validatedElements.contains(enclosingElement)) {
 								isElementRemaining = true;
 							} else {
-								LOGGER.error("Enclosing element {} has not been successfully validated", annotatedElement, enclosingElement);
+								LOGGER.error(annotatedElement, "Enclosing element {} has not been successfully validated", enclosingElement);
 							}
 						} else {
 							GeneratedClassHolder generatedClassHolder = generatingAnnotationHandler.createGeneratedClassHolder(environment, typeElement);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
@@ -75,7 +75,7 @@ public class ModelValidator {
 				}
 
 				for (String warning : elementValidation.getWarnings()) {
-					LOGGER.warn(warning, elementValidation.getElement(), annotationMirror);
+					LOGGER.warn(elementValidation.getElement(), annotationMirror, warning);
 				}
 
 				if (elementValidation.isValid()) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
@@ -81,7 +81,7 @@ public class ModelValidator {
 				if (elementValidation.isValid()) {
 					validatedAnnotatedElements.add(annotatedElement);
 				} else {
-					LOGGER.warn("Element {} invalidated by {}", annotatedElement, annotatedElement, validatorSimpleName);
+					LOGGER.warn(annotatedElement, "Element {} invalidated by {}", annotatedElement, validatorSimpleName);
 				}
 			}
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/process/ModelValidator.java
@@ -71,7 +71,7 @@ public class ModelValidator {
 
 				AnnotationMirror annotationMirror = elementValidation.getAnnotationMirror();
 				for (ElementValidation.Error error : elementValidation.getErrors()) {
-					LOGGER.error(error.getMessage(), error.getElement(), annotationMirror);
+					LOGGER.error(error.getElement(), annotationMirror, error.getMessage());
 				}
 
 				for (String warning : elementValidation.getWarnings()) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -42,15 +42,11 @@ public class Logger {
 	}
 
 	public void warn(String message, Object... args) {
-		warn(message, null, null, args);
+		warn(null, message, args);
 	}
 
-	public void warn(String message, Element element, Object... args) {
-		warn(message, element, null, args);
-	}
-
-	public void warn(String message, Element element, Throwable thr, Object... args) {
-		log(Level.WARN, message, element, null, thr, args);
+	public void warn(Element element, String message, Object... args) {
+		log(Level.WARN, message, element, null, null, args);
 	}
 
 	public void warn(String message, Element element, AnnotationMirror annotationMirror) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -54,18 +54,18 @@ public class Logger {
 	}
 
 	public void error(String message, Object... args) {
-		error(message, null, null, args);
+		error(null, null, message, args);
 	}
 
 	public void error(Element element, String message, Object... args) {
-		error(message, element, null, args);
+		error(element, null, message, args);
 	}
 
 	public void error(Throwable thr, String message, Object... args) {
-		error(message, null, thr, args);
+		error(null, thr, message, args);
 	}
 
-	public void error(String message, Element element, Throwable thr, Object... args) {
+	public void error(Element element, Throwable thr, String message, Object... args) {
 		log(Level.ERROR, message, element, null, thr, args);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -45,10 +45,6 @@ public class Logger {
 		warn(message, null, null, args);
 	}
 
-	public void warn(String message, Throwable thr, Object... args) {
-		warn(message, null, thr, args);
-	}
-
 	public void warn(String message, Element element, Object... args) {
 		warn(message, element, null, args);
 	}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -34,11 +34,7 @@ public class Logger {
 	}
 
 	public void debug(String message, Object... args) {
-		debug(message, null, args);
-	}
-
-	public void debug(String message, Element element, Object... args) {
-		log(Level.DEBUG, message, element, null, null, args);
+		log(Level.DEBUG, message, null, null, null, args);
 	}
 
 	public void info(String message, Object... args) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -61,7 +61,7 @@ public class Logger {
 		error(message, element, null, args);
 	}
 
-	public void error(String message, Throwable thr, Object... args) {
+	public void error(Throwable thr, String message, Object... args) {
 		error(message, null, thr, args);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -38,11 +38,7 @@ public class Logger {
 	}
 
 	public void info(String message, Object... args) {
-		info(message, null, args);
-	}
-
-	public void info(String message, Element element, Object... args) {
-		log(Level.INFO, message, element, null, null, args);
+		log(Level.INFO, message, null, null, null, args);
 	}
 
 	public void warn(String message, Object... args) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -57,7 +57,7 @@ public class Logger {
 		error(message, null, null, args);
 	}
 
-	public void error(String message, Element element, Object... args) {
+	public void error(Element element, String message, Object... args) {
 		error(message, element, null, args);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -49,7 +49,7 @@ public class Logger {
 		log(Level.WARN, message, element, null, null, args);
 	}
 
-	public void warn(String message, Element element, AnnotationMirror annotationMirror) {
+	public void warn(Element element, AnnotationMirror annotationMirror, String message) {
 		log(Level.WARN, message, element, annotationMirror, null);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -77,7 +77,7 @@ public class Logger {
 		return level.isGreaterOrEquals(loggerContext.getCurrentLevel());
 	}
 
-	public void log(Level level, String message, Element element, AnnotationMirror annotationMirror, Throwable thr, Object... args) {
+	private void log(Level level, String message, Element element, AnnotationMirror annotationMirror, Throwable thr, Object... args) {
 		if (!isLoggable(level)) {
 			return;
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -69,7 +69,7 @@ public class Logger {
 		log(Level.ERROR, message, element, null, thr, args);
 	}
 
-	public void error(String message, Element element, AnnotationMirror annotationMirror) {
+	public void error(Element element, AnnotationMirror annotationMirror, String message) {
 		log(Level.ERROR, message, element, annotationMirror, null);
 	}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/logger/Logger.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2018 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,11 +30,7 @@ public class Logger {
 	}
 
 	public void trace(String message, Object... args) {
-		trace(message, null, args);
-	}
-
-	public void trace(String message, Element element, Object... args) {
-		log(Level.TRACE, message, element, null, null, args);
+		log(Level.TRACE, message, null, null, null, args);
 	}
 
 	public void debug(String message, Object... args) {


### PR DESCRIPTION
This PR is intended to fix the logging issue mentioned in #2145 and prevent similar misuse in the future.

While the only place where this issue actually hapened where two `trace()` statements in `ModelProcessor` I refactored the log methods to have the `message` argument last or second to last if there are `args` allowed.