### PR TITLE
Fix the order of some Android X checks to avoid conflicts with Support v4

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/ContextCompatAwareResHandler.java
@@ -45,10 +45,10 @@ abstract class ContextCompatAwareResHandler extends AbstractResHandler {
 
 	@Override
 	protected IJExpression getInstanceInvocation(EComponentHolder holder, JFieldRef idRef, IJAssignmentTarget fieldRef, JBlock targetBlock) {
-		if (hasTargetMethodInContextCompat()) {
-			return getClasses().CONTEXT_COMPAT.staticInvoke(androidRes.getResourceMethodName()).arg(holder.getContextRef()).arg(idRef);
-		} else if (hasTargetMethodInAndroidxContextCompat()) {
+		if (hasTargetMethodInAndroidxContextCompat()) {
 			return getClasses().ANDROIDX_CONTEXT_COMPAT.staticInvoke(androidRes.getResourceMethodName()).arg(holder.getContextRef()).arg(idRef);
+		} else if (hasTargetMethodInContextCompat()) {
+			return getClasses().CONTEXT_COMPAT.staticInvoke(androidRes.getResourceMethodName()).arg(holder.getContextRef()).arg(idRef);
 		} else if (shouldUseContextMethod()) {
 			return holder.getContextRef().invoke(androidRes.getResourceMethodName()).arg(idRef);
 		} else if (!shouldUseContextMethod() && hasTargetMethodInContext()) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PreferenceChangeHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PreferenceChangeHandler.java
@@ -119,7 +119,7 @@ public class PreferenceChangeHandler extends AbstractPreferenceListenerHandler {
 
 	@Override
 	protected AbstractJClass getListenerClass(HasPreferences holder) {
-		return holder.usingSupportV7Preference() ? getClasses().SUPPORT_V7_PREFERENCE_CHANGE_LISTENER
-				: holder.usingAndroidxPreference() ? getClasses().ANDROIDX_PREFERENCE_CHANGE_LISTENER : getClasses().PREFERENCE_CHANGE_LISTENER;
+		return holder.usingAndroidxPreference() ? getClasses().ANDROIDX_PREFERENCE_CHANGE_LISTENER
+				: holder.usingSupportV7Preference() ? getClasses().SUPPORT_V7_PREFERENCE_CHANGE_LISTENER : getClasses().PREFERENCE_CHANGE_LISTENER;
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PreferenceClickHandler.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/handler/PreferenceClickHandler.java
@@ -92,8 +92,8 @@ public class PreferenceClickHandler extends AbstractPreferenceListenerHandler {
 
 	@Override
 	protected AbstractJClass getListenerClass(HasPreferences holder) {
-		return holder.usingSupportV7Preference() ? getClasses().SUPPORT_V7_PREFERENCE_CLICK_LISTENER
-				: holder.usingAndroidxPreference() ? getClasses().ANDROIDX_PREFERENCE_CLICK_LISTENER : getClasses().PREFERENCE_CLICK_LISTENER;
+		return holder.usingAndroidxPreference() ? getClasses().ANDROIDX_PREFERENCE_CLICK_LISTENER
+				: holder.usingSupportV7Preference() ? getClasses().SUPPORT_V7_PREFERENCE_CLICK_LISTENER : getClasses().PREFERENCE_CLICK_LISTENER;
 	}
 
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/ActivityIntentBuilder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/ActivityIntentBuilder.java
@@ -239,14 +239,14 @@ public class ActivityIntentBuilder extends IntentBuilder {
 	}
 
 	private AbstractJClass getActivityCompat() {
-		TypeElement activityCompat = elementUtils.getTypeElement(CanonicalNameConstants.ACTIVITY_COMPAT);
-		if (hasActivityOptions(activityCompat, 2)) {
-			return getClasses().ACTIVITY_COMPAT;
-		}
-
 		TypeElement androidxActivityCompat = elementUtils.getTypeElement(CanonicalNameConstants.ANDROIDX_ACTIVITY_COMPAT);
 		if (hasActivityOptions(androidxActivityCompat, 2)) {
 			return getClasses().ANDROIDX_ACTIVITY_COMPAT;
+		}
+
+		TypeElement activityCompat = elementUtils.getTypeElement(CanonicalNameConstants.ACTIVITY_COMPAT);
+		if (hasActivityOptions(activityCompat, 2)) {
+			return getClasses().ACTIVITY_COMPAT;
 		}
 
 		return null;

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/ActivityIntentBuilder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/core/helper/ActivityIntentBuilder.java
@@ -80,16 +80,15 @@ public class ActivityIntentBuilder extends IntentBuilder {
 			JVar fragmentParam = method.param(getClasses().FRAGMENT, "fragment");
 			method.body()._return(_new(holder.getIntentBuilderClass()).arg(fragmentParam));
 		}
-		if (hasFragmentSupportInClasspath()) {
-			// intent() with android.support.v4.app.Fragment param
-			JMethod method = holder.getGeneratedClass().method(STATIC | PUBLIC, holder.getIntentBuilderClass(), "intent");
-			JVar fragmentParam = method.param(getClasses().SUPPORT_V4_FRAGMENT, "supportFragment");
-			method.body()._return(_new(holder.getIntentBuilderClass()).arg(fragmentParam));
-		}
 		if (hasAndroidxFragmentInClasspath()) {
 			// intent() with androidx.fragment.app.Fragment param
 			JMethod method = holder.getGeneratedClass().method(STATIC | PUBLIC, holder.getIntentBuilderClass(), "intent");
 			JVar fragmentParam = method.param(getClasses().ANDROIDX_FRAGMENT, "supportFragment");
+			method.body()._return(_new(holder.getIntentBuilderClass()).arg(fragmentParam));
+		} else if (hasFragmentSupportInClasspath()) {
+			// intent() with android.support.v4.app.Fragment param
+			JMethod method = holder.getGeneratedClass().method(STATIC | PUBLIC, holder.getIntentBuilderClass(), "intent");
+			JVar fragmentParam = method.param(getClasses().SUPPORT_V4_FRAGMENT, "supportFragment");
 			method.body()._return(_new(holder.getIntentBuilderClass()).arg(fragmentParam));
 		}
 	}
@@ -104,11 +103,10 @@ public class ActivityIntentBuilder extends IntentBuilder {
 		if (hasFragmentInClasspath()) {
 			fragmentField = addFragmentConstructor(getClasses().FRAGMENT, "fragment" + generationSuffix());
 		}
-		if (hasFragmentSupportInClasspath()) {
-			fragmentSupportField = addFragmentConstructor(getClasses().SUPPORT_V4_FRAGMENT, "fragmentSupport" + generationSuffix());
-		}
 		if (hasAndroidxFragmentInClasspath()) {
 			fragmentSupportField = addFragmentConstructor(getClasses().ANDROIDX_FRAGMENT, "fragmentSupport" + generationSuffix());
+		} else if (hasFragmentSupportInClasspath()) {
+			fragmentSupportField = addFragmentConstructor(getClasses().SUPPORT_V4_FRAGMENT, "fragmentSupport" + generationSuffix());
 		}
 	}
 


### PR DESCRIPTION
See #2168 

A project that is migrated to Android X no longer has support v4 classes on its classpath... at least it seems so.

One can have a project migrated to Android X and thus is no longer able to import e.g. `android.support.v4.app.Fragment` in own code. If no 3rd party library is using the support v4 fragment compiling with AA 4.5.0 is no problem. Having a 3rd party dependency that uses support v4 does not mean you can use the classes in your code as there is a tool called `jetifier` that migrates the 3rd party code on the fly to use Android X. but during the actual build process the support v4 classes are still on classpath and so available to AndroidAnnotations.

In the Android X support PR #2149 this was not known and thus we have some cases where the build fails with android x + support v4 libs on classpath.

This PR aims to fix the issue by changing order of checks so that Android X dominates support v4.