### PR TITLE
Ensure that `kotlin.Metadata` is not copied to generated class

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/helper/APTCodeModelHelper.java
@@ -78,6 +78,8 @@ import com.helger.jcodemodel.JVar;
 
 public class APTCodeModelHelper {
 
+	private static final List<String> IGNORED_ANNOTATIONS = Collections.singletonList("kotlin.Metadata");
+
 	private AndroidAnnotationsEnvironment environment;
 
 	public APTCodeModelHelper(AndroidAnnotationsEnvironment environment) {
@@ -318,7 +320,7 @@ public class APTCodeModelHelper {
 		for (AnnotationMirror annotationMirror : annotationMirrors) {
 			if (annotationMirror.getAnnotationType().asElement().getAnnotation(Inherited.class) == null) {
 				AbstractJClass annotationClass = typeMirrorToJClass(annotationMirror.getAnnotationType());
-				if (!environment.isAndroidAnnotation(annotationClass.fullName())) {
+				if (!environment.isAndroidAnnotation(annotationClass.fullName()) && !IGNORED_ANNOTATIONS.contains(annotationClass.fullName())) {
 					copyAnnotation(annotatable, annotationMirror);
 				}
 			}


### PR DESCRIPTION
Currently we copy all non AA annotations to the generated class. This inlcudes `kotlin.Metadata` annotation and causes some Problems, with this PR we ensure to not copy this annotation.

See https://github.com/androidannotations/androidannotations/issues/2082