### PR TITLE
Support Android Build Plugin 3.3.0-beta1

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -229,12 +229,15 @@ public class AndroidManifestFinder {
 				variantPart = sb.toString();
 			}
 
-			String processManifest = "process" + upperCaseFirst(variantPart) + "Manifest";
-			String possibleLocation = BUILD_TOOLS_V32_MANIFEST_PATH + "/" + variantPart + "/" + processManifest + "/merged";
-			File variantDir = new File(basePath + possibleLocation);
-			if (variantDir.isDirectory()) {
-				possibleLocations.add(possibleLocation);
-				addPossibleSplitLocations(basePath, possibleLocation, possibleLocations);
+			String possibleLocation = BUILD_TOOLS_V32_MANIFEST_PATH + "/" + variantPart;
+			findPossibleLocations(basePath, possibleLocations, possibleLocation);
+			findPossibleLocations(basePath, possibleLocations, possibleLocation + "/process" + upperCaseFirst(variantPart) + "Manifest/merged");
+		}
+
+		private void findPossibleLocations(String basePath, List<String> possibleLocations, String possibleLocationWithProcessManifest) {
+			if (new File(basePath, possibleLocationWithProcessManifest).isDirectory()) {
+				possibleLocations.add(possibleLocationWithProcessManifest);
+				addPossibleSplitLocations(basePath, possibleLocationWithProcessManifest, possibleLocations);
 			}
 		}
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -80,6 +80,13 @@ public class AndroidManifestFinderTest {
 		Object[] gradleManifestFoundInMergedManifestsWithBothSplit = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86/hdpi", true };
 		Object[] gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86/hdpi",
 				true };
+		Object[] gradleManifestFoundInMergedManifestsV33 = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplitV33 = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/x86", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33 = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/x86", true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplitV33 = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33 = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplitV33 = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/x86/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV33 = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/x86/hdpi", true };
 
 		Object[] gradleKotlinManifestFoundInManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleKotlinManifestFoundInBundles = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/bundles/debug", true };
@@ -103,6 +110,13 @@ public class AndroidManifestFinderTest {
 		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplit = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/processDebugManifest/merged/x86/hdpi", true };
 		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER,
 				"build/intermediates/merged_manifests/flavorDebug/processFlavorDebugManifest/merged/x86/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsV33 = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithAbiSplitV33 = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/x86", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33 = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/x86", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithDensitySplitV33 = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33 = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplitV33 = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/merged_manifests/debug/x86/hdpi", true };
+		Object[] gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavorV33 = { GRADLE_KOTLIN_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/x86/hdpi", true };
 		// CHECKSTYLE:ON
 
 		Object[] mavenManifestFoundInTarget = { MAVEN_GEN_FOLDER, "target", true };
@@ -126,14 +140,19 @@ public class AndroidManifestFinderTest {
 				gradleManifestFoundInManifestsWithDensitySplit, gradleManifestFoundInManifestsWithDensitySplitAndFlavor, gradleManifestFoundInManifestsWithBothSplit,
 				gradleManifestFoundInManifestsWithBothSplitAndFlavor, gradleManifestFoundInMergedManifests, gradleManifestFoundInMergedManifestsWithAbiSplit,
 				gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleManifestFoundInMergedManifestsWithDensitySplit, gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavor,
-				gradleManifestFoundInMergedManifestsWithBothSplit, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles,
-				gradleKotlinManifestFoundInManifestsAapt, gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor,
-				gradleKotlinManifestFoundInManifestsAaptWithFlavor, gradleKotlinManifestFoundInManifestsWithAbiSplit, gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor,
-				gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInManifestsWithBothSplit,
-				gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifests, gradleKotlinManifestFoundInMergedManifestsWithAbiSplit,
-				gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithDensitySplit,
+				gradleManifestFoundInMergedManifestsWithBothSplit, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleManifestFoundInMergedManifestsV33,
+				gradleManifestFoundInMergedManifestsWithAbiSplitV33, gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33, gradleManifestFoundInMergedManifestsWithDensitySplitV33,
+				gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33, gradleManifestFoundInMergedManifestsWithBothSplitV33, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV33,
+				gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt, gradleKotlinManifestFoundInManifestsWithFlavor,
+				gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor, gradleKotlinManifestFoundInManifestsWithAbiSplit,
+				gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor,
+				gradleKotlinManifestFoundInManifestsWithBothSplit, gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifests,
+				gradleKotlinManifestFoundInMergedManifestsWithAbiSplit, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithDensitySplit,
 				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithBothSplit,
-				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor, mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
+				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsV33, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitV33,
+				gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33, gradleKotlinManifestFoundInMergedManifestsWithDensitySplitV33,
+				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33, gradleKotlinManifestFoundInMergedManifestsWithBothSplitV33,
+				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavorV33, mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
 				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound, noGeneratedFolderFound);
 	}
 


### PR DESCRIPTION
Google once again moved the location of merged AndroidManifest.xml... this PR allows AA to find the Manifest in its new location.

Tested with `3.3.0-beta01` and `3.4.0-alpha02`

See #2173