### PR TITLE
Add "method" to all the fields in the Holders which references JMetho…

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EActivityHolder.java
@@ -54,13 +54,14 @@ import com.helger.jcodemodel.JMethod;
 import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.JVar;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class EActivityHolder extends EComponentWithViewSupportHolder
 		implements HasIntentBuilder, HasExtras, HasInstanceState, HasOptionsMenu, HasOnActivityResult, HasActivityLifecycleMethods, HasReceiverRegistration, HasPreferenceHeaders {
 
 	private ActivityIntentBuilder intentBuilder;
-	private JMethod onCreate;
-	private JMethod setIntent;
-	private JMethod setContentViewLayout;
+	private JMethod onCreateMethod;
+	private JMethod setIntentMethod;
+	private JMethod setContentViewLayoutMethod;
 	private JVar initSavedInstanceParam;
 	private JDefinedClass intentBuilderClass;
 	private InstanceStateDelegate instanceStateDelegate;
@@ -70,25 +71,31 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	private JMethod injectExtrasMethod;
 	private JBlock injectExtrasBlock;
 	private JVar injectExtras;
+	private JMethod onCreateOptionsMenuMethod;
 	private JBlock onCreateOptionsMenuMethodBody;
 	private JBlock onCreateOptionsMenuMethodInflateBody;
 	private JVar onCreateOptionsMenuMenuInflaterVar;
 	private JVar onCreateOptionsMenuMenuParam;
+	private JMethod onOptionsItemSelectedMethod;
 	private JVar onOptionsItemSelectedItem;
 	private JVar onOptionsItemSelectedItemId;
 	private JBlock onOptionsItemSelectedMiddleBlock;
 	private NonConfigurationHolder nonConfigurationHolder;
 	private JBlock initIfNonConfigurationNotNullBlock;
 	private JVar initNonConfigurationInstance;
-	private JMethod getLastNonConfigurationInstance;
+	private JMethod getLastNonConfigurationInstanceMethod;
 	private JBlock onRetainNonConfigurationInstanceBindBlock;
 	private JVar onRetainNonConfigurationInstance;
+	private JMethod onStartMethod;
 	private JBlock onStartBeforeSuperBlock;
 	private JBlock onStartAfterSuperBlock;
+	private JMethod onRestartMethod;
 	private JBlock onRestartBeforeSuperBlock;
 	private JBlock onRestartAfterSuperBlock;
+	private JMethod onResumeMethod;
 	private JBlock onResumeBeforeSuperBlock;
 	private JBlock onResumeAfterSuperBlock;
+	private JMethod onPauseMethod;
 	private JBlock onPauseBeforeSuperBlock;
 	private JBlock onPauseAfterSuperBlock;
 	private JMethod onStopMethod;
@@ -98,10 +105,11 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	private JBlock onDestroyAfterSuperBlock;
 	private JMethod onNewIntentMethod;
 	private JBlock onNewIntentAfterSuperBlock;
+	private JMethod onConfigurationChangedMethod;
 	private JBlock onConfigurationChangedBeforeSuperBlock;
 	private JBlock onConfigurationChangedAfterSuperBlock;
 	private JVar onConfigurationChangedNewConfigParam;
-	private JMethod onContentChanged;
+	private JMethod onContentChangedMethod;
 	private JBlock onContentChangedAfterSuperBlock;
 
 	public EActivityHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement, AndroidManifest androidManifest) throws Exception {
@@ -123,47 +131,54 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 		AbstractJClass bundleClass = getClasses().BUNDLE;
-		initSavedInstanceParam = init.param(bundleClass, "savedInstanceState");
+		initSavedInstanceParam = initMethod.param(bundleClass, "savedInstanceState");
 		getOnCreate();
 	}
 
 	public JMethod getOnCreate() {
-		if (onCreate == null) {
+		if (onCreateMethod == null) {
 			setOnCreate();
 		}
-		return onCreate;
+		return onCreateMethod;
 	}
 
 	public JMethod getSetIntent() {
-		if (setIntent == null) {
+		if (setIntentMethod == null) {
 			setSetIntent();
 		}
-		return setIntent;
+		return setIntentMethod;
 	}
 
 	private void setOnCreate() {
-		onCreate = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
-		onCreate.annotate(Override.class);
+		onCreateMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
+		onCreateMethod.annotate(Override.class);
 		AbstractJClass bundleClass = getClasses().BUNDLE;
-		JVar onCreateSavedInstanceState = onCreate.param(bundleClass, "savedInstanceState");
-		JBlock onCreateBody = onCreate.body();
+		JVar onCreateSavedInstanceState = onCreateMethod.param(bundleClass, "savedInstanceState");
+		JBlock onCreateBody = onCreateMethod.body();
 		JVar previousNotifier = viewNotifierHelper.replacePreviousNotifier(onCreateBody);
 		onCreateBody.add(JExpr.invoke(getInit()).arg(onCreateSavedInstanceState));
-		onCreateBody.add(_super().invoke(onCreate).arg(onCreateSavedInstanceState));
+		onCreateBody.add(_super().invoke(onCreateMethod).arg(onCreateSavedInstanceState));
 		viewNotifierHelper.resetPreviousNotifier(onCreateBody, previousNotifier);
 	}
 
 	// CHECKSTYLE:OFF
 
 	private void setOnStart() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onStart");
-		method.annotate(Override.class);
-		JBlock body = method.body();
+		onStartMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onStart");
+		onStartMethod.annotate(Override.class);
+		JBlock body = onStartMethod.body();
 		onStartBeforeSuperBlock = body.blockSimple();
-		body.invoke(_super(), method);
+		body.invoke(_super(), onStartMethod);
 		onStartAfterSuperBlock = body.blockSimple();
+	}
+
+	public JMethod getOnRestart() {
+		if (onRestartMethod == null) {
+			setOnRestart();
+		}
+		return onRestartMethod;
 	}
 
 	public JBlock getOnRestartAfterSuperBlock() {
@@ -174,29 +189,29 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnRestart() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onRestart");
-		method.annotate(Override.class);
-		JBlock body = method.body();
+		onRestartMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onRestart");
+		onRestartMethod.annotate(Override.class);
+		JBlock body = onRestartMethod.body();
 		onRestartBeforeSuperBlock = body.blockSimple();
-		body.invoke(_super(), method);
+		body.invoke(_super(), onRestartMethod);
 		onRestartAfterSuperBlock = body.blockSimple();
 	}
 
 	private void setOnResume() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onResume");
-		method.annotate(Override.class);
-		JBlock body = method.body();
+		onResumeMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onResume");
+		onResumeMethod.annotate(Override.class);
+		JBlock body = onResumeMethod.body();
 		onResumeBeforeSuperBlock = body.blockSimple();
-		body.invoke(_super(), method);
+		body.invoke(_super(), onResumeMethod);
 		onResumeAfterSuperBlock = body.blockSimple();
 	}
 
 	private void setOnPause() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onPause");
-		method.annotate(Override.class);
-		JBlock body = method.body();
+		onPauseMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onPause");
+		onPauseMethod.annotate(Override.class);
+		JBlock body = onPauseMethod.body();
 		onPauseBeforeSuperBlock = body.blockSimple();
-		body.invoke(_super(), method);
+		body.invoke(_super(), onPauseMethod);
 		onPauseAfterSuperBlock = body.blockSimple();
 	}
 
@@ -210,18 +225,11 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setSetIntent() {
-		setIntent = generatedClass.method(PUBLIC, getCodeModel().VOID, "setIntent");
-		setIntent.annotate(Override.class);
-		JVar methodParam = setIntent.param(getClasses().INTENT, "newIntent");
-		JBlock setIntentBody = setIntent.body();
-		setIntentBody.add(_super().invoke(setIntent).arg(methodParam));
-	}
-
-	public JMethod getOnStop() {
-		if (onStopMethod == null) {
-			setOnStop();
-		}
-		return onStopMethod;
+		setIntentMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "setIntent");
+		setIntentMethod.annotate(Override.class);
+		JVar methodParam = setIntentMethod.param(getClasses().INTENT, "newIntent");
+		JBlock setIntentBody = setIntentMethod.body();
+		setIntentBody.add(_super().invoke(setIntentMethod).arg(methodParam));
 	}
 
 	private void setOnStop() {
@@ -248,6 +256,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		onDestroyAfterSuperBlock = body.blockSimple();
 	}
 
+	public JMethod getOnConfigurationChanged() {
+		if (onConfigurationChangedMethod == null) {
+			setOnConfigurationChanged();
+		}
+		return onConfigurationChangedMethod;
+	}
+
 	public JBlock getOnConfigurationChangedBeforeSuperBlock() {
 		if (onConfigurationChangedBeforeSuperBlock == null) {
 			setOnConfigurationChanged();
@@ -270,21 +285,21 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnConfigurationChanged() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onConfigurationChanged");
-		method.annotate(Override.class);
+		onConfigurationChangedMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onConfigurationChanged");
+		onConfigurationChangedMethod.annotate(Override.class);
 		AbstractJClass configurationClass = getClasses().CONFIGURATION;
-		onConfigurationChangedNewConfigParam = method.param(configurationClass, "newConfig");
-		JBlock body = method.body();
+		onConfigurationChangedNewConfigParam = onConfigurationChangedMethod.param(configurationClass, "newConfig");
+		JBlock body = onConfigurationChangedMethod.body();
 		onConfigurationChangedBeforeSuperBlock = body.blockSimple();
-		body.add(_super().invoke(method).arg(onConfigurationChangedNewConfigParam));
+		body.add(_super().invoke(onConfigurationChangedMethod).arg(onConfigurationChangedNewConfigParam));
 		onConfigurationChangedAfterSuperBlock = body.blockSimple();
 	}
 
 	public JMethod getOnContentChanged() {
-		if (onContentChanged == null) {
+		if (onContentChangedMethod == null) {
 			setOnContentChanged();
 		}
-		return onContentChanged;
+		return onContentChangedMethod;
 	}
 
 	public JBlock getOnContentChangedAfterSuperBlock() {
@@ -295,86 +310,80 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnContentChanged() {
-		onContentChanged = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onContentChanged");
-		onContentChanged.annotate(Override.class);
-		JBlock body = onContentChanged.body();
-		body.invoke(_super(), onContentChanged);
+		onContentChangedMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().VOID, "onContentChanged");
+		onContentChangedMethod.annotate(Override.class);
+		JBlock body = onContentChangedMethod.body();
+		body.invoke(_super(), onContentChangedMethod);
 		onContentChangedAfterSuperBlock = body.blockSimple();
 	}
 
 	private void setOnCreateOptionsMenu() {
-		JMethod method = generatedClass.method(PUBLIC, getCodeModel().BOOLEAN, "onCreateOptionsMenu");
-		method.annotate(Override.class);
-		JBlock methodBody = method.body();
-		onCreateOptionsMenuMenuParam = method.param(getClasses().MENU, "menu");
+		onCreateOptionsMenuMethod = generatedClass.method(PUBLIC, getCodeModel().BOOLEAN, "onCreateOptionsMenu");
+		onCreateOptionsMenuMethod.annotate(Override.class);
+		JBlock methodBody = onCreateOptionsMenuMethod.body();
+		onCreateOptionsMenuMenuParam = onCreateOptionsMenuMethod.param(getClasses().MENU, "menu");
 		onCreateOptionsMenuMenuInflaterVar = methodBody.decl(getClasses().MENU_INFLATER, "menuInflater", invoke("getMenuInflater"));
 		onCreateOptionsMenuMethodInflateBody = methodBody.blockSimple();
 		onCreateOptionsMenuMethodBody = methodBody.blockSimple();
-		methodBody._return(_super().invoke(method).arg(onCreateOptionsMenuMenuParam));
+		methodBody._return(_super().invoke(onCreateOptionsMenuMethod).arg(onCreateOptionsMenuMenuParam));
 	}
 
 	private void setOnOptionsItemSelected() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().BOOLEAN, "onOptionsItemSelected");
-		method.annotate(Override.class);
-		JBlock methodBody = method.body();
-		onOptionsItemSelectedItem = method.param(getClasses().MENU_ITEM, "item");
+		onOptionsItemSelectedMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().BOOLEAN, "onOptionsItemSelected");
+		onOptionsItemSelectedMethod.annotate(Override.class);
+		JBlock methodBody = onOptionsItemSelectedMethod.body();
+		onOptionsItemSelectedItem = onOptionsItemSelectedMethod.param(getClasses().MENU_ITEM, "item");
 		onOptionsItemSelectedItemId = methodBody.decl(getCodeModel().INT, "itemId_", onOptionsItemSelectedItem.invoke("getItemId"));
 		onOptionsItemSelectedMiddleBlock = methodBody.blockSimple();
 
-		methodBody._return(invoke(_super(), method).arg(onOptionsItemSelectedItem));
+		methodBody._return(invoke(_super(), onOptionsItemSelectedMethod).arg(onOptionsItemSelectedItem));
 	}
 
 	@Override
 	protected void setFindNativeFragmentById() {
-		JMethod method = generatedClass.method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentById");
-		JVar idParam = method.param(getCodeModel().INT, "id");
-		JBlock body = method.body();
+		findNativeFragmentByIdMethod = generatedClass.method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentById");
+		JVar idParam = findNativeFragmentByIdMethod.param(getCodeModel().INT, "id");
+		JBlock body = findNativeFragmentByIdMethod.body();
 		body._return(invoke("getFragmentManager").invoke("findFragmentById").arg(idParam));
-		findNativeFragmentById = method;
 	}
 
 	@Override
 	protected void setFindSupportFragmentById() {
-		JMethod method;
 		if (getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.ANDROIDX_FRAGMENT) == null) {
-			method = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentById");
+			findSupportFragmentByIdMethod = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentById");
 		} else {
-			method = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentById");
+			findSupportFragmentByIdMethod = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentById");
 		}
-		JVar idParam = method.param(getCodeModel().INT, "id");
-		JBlock body = method.body();
+		JVar idParam = findSupportFragmentByIdMethod.param(getCodeModel().INT, "id");
+		JBlock body = findSupportFragmentByIdMethod.body();
 		body._return(invoke("getSupportFragmentManager").invoke("findFragmentById").arg(idParam));
-		findSupportFragmentById = method;
 	}
 
 	@Override
 	protected void setFindNativeFragmentByTag() {
-		JMethod method = generatedClass.method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentByTag");
-		JVar tagParam = method.param(getClasses().STRING, "tag");
-		JBlock body = method.body();
+		findNativeFragmentByTagMethod = generatedClass.method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentByTag");
+		JVar tagParam = findNativeFragmentByTagMethod.param(getClasses().STRING, "tag");
+		JBlock body = findNativeFragmentByTagMethod.body();
 		body._return(invoke("getFragmentManager").invoke("findFragmentByTag").arg(tagParam));
-		findNativeFragmentByTag = method;
 	}
 
 	@Override
 	protected void setFindSupportFragmentByTag() {
-		JMethod method;
 		if (getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.ANDROIDX_FRAGMENT) == null) {
-			method = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentByTag");
+			findSupportFragmentByTagMethod = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentByTag");
 		} else {
-			method = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentByTag");
+			findSupportFragmentByTagMethod = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentByTag");
 		}
-		JVar tagParam = method.param(getClasses().STRING, "tag");
-		JBlock body = method.body();
+		JVar tagParam = findSupportFragmentByTagMethod.param(getClasses().STRING, "tag");
+		JBlock body = findSupportFragmentByTagMethod.body();
 		body._return(invoke("getSupportFragmentManager").invoke("findFragmentByTag").arg(tagParam));
-		findSupportFragmentByTag = method;
 	}
 
 	public JMethod getSetContentViewLayout() {
-		if (setContentViewLayout == null) {
+		if (setContentViewLayoutMethod == null) {
 			setSetContentView();
 		}
-		return setContentViewLayout;
+		return setContentViewLayoutMethod;
 	}
 
 	private void setSetContentView() {
@@ -382,7 +391,7 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 
 		AbstractJClass layoutParamsClass = getClasses().VIEW_GROUP_LAYOUT_PARAMS;
 
-		setContentViewLayout = setContentViewMethod(new AbstractJType[] { getCodeModel().INT }, new String[] { "layoutResID" });
+		setContentViewLayoutMethod = setContentViewMethod(new AbstractJType[] { getCodeModel().INT }, new String[] { "layoutResID" });
 		setContentViewMethod(new AbstractJType[] { getClasses().VIEW, layoutParamsClass }, new String[] { "view", "params" });
 		setContentViewMethod(new AbstractJType[] { getClasses().VIEW }, new String[] { "view" });
 	}
@@ -466,6 +475,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		getInitBodyInjectionBlock().invoke(injectExtrasMethod);
 	}
 
+	public JMethod getOnNewIntent() {
+		if (onNewIntentMethod == null) {
+			setOnNewIntent();
+		}
+		return onNewIntentMethod;
+	}
+
 	public JBlock getOnNewIntentAfterSuperBlock() {
 		if (onNewIntentAfterSuperBlock == null) {
 			setOnNewIntent();
@@ -498,6 +514,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		return instanceStateDelegate.getRestoreStateBundleParam();
 	}
 
+	public JMethod getOnCreateOptionsMenu() {
+		if (onCreateOptionsMenuMethod == null) {
+			setOnCreateOptionsMenu();
+		}
+		return onCreateOptionsMenuMethod;
+	}
+
 	@Override
 	public JBlock getOnCreateOptionsMenuMethodBody() {
 		if (onCreateOptionsMenuMethodBody == null) {
@@ -528,6 +551,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 			setOnCreateOptionsMenu();
 		}
 		return onCreateOptionsMenuMenuParam;
+	}
+
+	public JMethod getOnOptionsItemSelected() {
+		if (onOptionsItemSelectedMethod == null) {
+			setOnOptionsItemSelected();
+		}
+		return onOptionsItemSelectedMethod;
 	}
 
 	@Override
@@ -587,10 +617,10 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 	}
 
 	public JMethod getGetLastNonConfigurationInstance() throws JClassAlreadyExistsException {
-		if (getLastNonConfigurationInstance == null) {
+		if (getLastNonConfigurationInstanceMethod == null) {
 			setGetLastNonConfigurationInstance();
 		}
-		return getLastNonConfigurationInstance;
+		return getLastNonConfigurationInstanceMethod;
 	}
 
 	private void setGetLastNonConfigurationInstance() throws JClassAlreadyExistsException {
@@ -606,10 +636,10 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		JDefinedClass ncHolderClass = ncHolder.getGeneratedClass();
 		JFieldVar superNonConfigurationInstanceField = ncHolder.getSuperNonConfigurationInstanceField();
 
-		getLastNonConfigurationInstance = generatedClass.method(PUBLIC, Object.class, getLastNonConfigurationInstanceName);
-		getLastNonConfigurationInstance.annotate(Override.class);
-		JBlock body = getLastNonConfigurationInstance.body();
-		JVar nonConfigurationInstance = body.decl(ncHolderClass, "nonConfigurationInstance", cast(ncHolderClass, _super().invoke(getLastNonConfigurationInstance)));
+		getLastNonConfigurationInstanceMethod = generatedClass.method(PUBLIC, Object.class, getLastNonConfigurationInstanceName);
+		getLastNonConfigurationInstanceMethod.annotate(Override.class);
+		JBlock body = getLastNonConfigurationInstanceMethod.body();
+		JVar nonConfigurationInstance = body.decl(ncHolderClass, "nonConfigurationInstance", cast(ncHolderClass, _super().invoke(getLastNonConfigurationInstanceMethod)));
 		body._if(nonConfigurationInstance.eq(_null()))._then()._return(_null());
 		body._return(nonConfigurationInstance.ref(superNonConfigurationInstanceField));
 	}
@@ -694,6 +724,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		return onDestroyAfterSuperBlock;
 	}
 
+	public JMethod getOnResume() {
+		if (onResumeMethod == null) {
+			setOnResume();
+		}
+		return onResumeMethod;
+	}
+
 	@Override
 	public JBlock getOnResumeAfterSuperBlock() {
 		if (onResumeAfterSuperBlock == null) {
@@ -715,6 +752,13 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		return onDestroyBeforeSuperBlock;
 	}
 
+	public JMethod getOnStart() {
+		if (onStartMethod == null) {
+			setOnStart();
+		}
+		return onStartMethod;
+	}
+
 	@Override
 	public JBlock getOnStartAfterSuperBlock() {
 		if (onStartAfterSuperBlock == null) {
@@ -723,12 +767,26 @@ public class EActivityHolder extends EComponentWithViewSupportHolder
 		return onStartAfterSuperBlock;
 	}
 
+	public JMethod getOnStop() {
+		if (onStopMethod == null) {
+			setOnStop();
+		}
+		return onStopMethod;
+	}
+
 	@Override
 	public JBlock getOnStopBeforeSuperBlock() {
 		if (onStopBeforeSuperBlock == null) {
 			setOnStop();
 		}
 		return onStopBeforeSuperBlock;
+	}
+
+	public JMethod getOnPause() {
+		if (onPauseMethod == null) {
+			setOnPause();
+		}
+		return onPauseMethod;
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EApplicationHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EApplicationHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2019 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -75,6 +76,6 @@ public class EApplicationHolder extends EComponentHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EBeanHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EBeanHolder.java
@@ -51,6 +51,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 	private JFieldVar contextField;
 
 	private JMethod constructor;
+	private JMethod factoryMethod;
 	private JMethod overloadedConstructor;
 
 	public EBeanHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement) throws Exception {
@@ -106,7 +107,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 	}
 
 	public void invokeInitInConstructors() {
@@ -121,7 +122,7 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 
 		AbstractJClass narrowedGeneratedClass = codeModelHelper.narrowGeneratedClass(generatedClass, annotatedElement.asType());
 
-		JMethod factoryMethod = generatedClass.method(PUBLIC | STATIC, narrowedGeneratedClass, GET_INSTANCE_METHOD_NAME);
+		factoryMethod = generatedClass.method(PUBLIC | STATIC, narrowedGeneratedClass, GET_INSTANCE_METHOD_NAME);
 		codeModelHelper.generify(factoryMethod, annotatedElement);
 
 		JVar factoryMethodContextParam = factoryMethod.param(getClasses().CONTEXT, "context");
@@ -162,6 +163,10 @@ public class EBeanHolder extends EComponentWithViewSupportHolder {
 			factoryMethodBody._return(instanceField);
 			break;
 		}
+	}
+	
+	public JMethod getFactoryMethod() {
+		return factoryMethod;
 	}
 
 	private void createOverloadedFactoryMethod(EBean.Scope scope) {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentHolder.java
@@ -36,8 +36,7 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 
 	protected IJExpression contextRef;
 	protected IJExpression rootFragmentRef;
-
-	protected JMethod init;
+	protected JMethod initMethod;
 	private JBlock initBodyBeforeInjectionBlock;
 	private JBlock initBodyInjectionBlock;
 	private JBlock initBodyAfterInjectionBlock;
@@ -69,10 +68,10 @@ public abstract class EComponentHolder extends BaseGeneratedClassHolder {
 	}
 
 	public JMethod getInit() {
-		if (init == null) {
+		if (initMethod == null) {
 			setInit();
 		}
-		return init;
+		return initMethod;
 	}
 
 	protected abstract void setInit();

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EComponentWithViewSupportHolder.java
@@ -57,7 +57,7 @@ import com.helger.jcodemodel.JVar;
 public abstract class EComponentWithViewSupportHolder extends EComponentHolder implements HasKeyEventCallbackMethods {
 
 	protected ViewNotifierHelper viewNotifierHelper;
-	private JMethod onViewChanged;
+	private JMethod onViewChangedMethod;
 	private JBlock onViewChangedBody;
 	private JBlock onViewChangedBodyInjectionBlock;
 	private JBlock onViewChangedBodyViewHolderBlock;
@@ -66,10 +66,10 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	private JVar onViewChangedHasViewsParam;
 	protected Map<String, FoundHolder> foundHolders = new HashMap<>();
 	protected DataBindingDelegate dataBindingDelegate;
-	protected JMethod findNativeFragmentById;
-	protected JMethod findSupportFragmentById;
-	protected JMethod findNativeFragmentByTag;
-	protected JMethod findSupportFragmentByTag;
+	protected JMethod findNativeFragmentByIdMethod;
+	protected JMethod findSupportFragmentByIdMethod;
+	protected JMethod findNativeFragmentByTagMethod;
+	protected JMethod findSupportFragmentByTagMethod;
 	private Map<String, TextWatcherHolder> textWatcherHolders = new HashMap<>();
 	private Map<String, OnSeekBarChangeListenerHolder> onSeekBarChangeListenerHolders = new HashMap<>();
 	private Map<String, PageChangeHolder> pageChangeHolders = new HashMap<>();
@@ -80,6 +80,13 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 		viewNotifierHelper = new ViewNotifierHelper(this, environment);
 		keyEventCallbackMethodsDelegate = new KeyEventCallbackMethodsDelegate<>(this);
 		dataBindingDelegate = new DataBindingDelegate(this);
+	}
+	
+	public JMethod getOnViewChanged() {
+		if (onViewChangedMethod == null) {
+			setOnViewChanged();
+		}
+		return onViewChangedMethod;
 	}
 
 	public IJExpression getFindViewByIdExpression(JVar idParam) {
@@ -130,14 +137,14 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 
 	protected void setOnViewChanged() {
 		getGeneratedClass()._implements(OnViewChangedListener.class);
-		onViewChanged = getGeneratedClass().method(PUBLIC, getCodeModel().VOID, "onViewChanged");
-		onViewChanged.annotate(Override.class);
-		onViewChangedBody = onViewChanged.body();
+		onViewChangedMethod = getGeneratedClass().method(PUBLIC, getCodeModel().VOID, "onViewChanged");
+		onViewChangedMethod.annotate(Override.class);
+		onViewChangedBody = onViewChangedMethod.body();
 		onViewChangedBodyBeforeInjectionBlock = onViewChangedBody.blockVirtual();
 		onViewChangedBodyViewHolderBlock = onViewChangedBody.blockVirtual();
 		onViewChangedBodyInjectionBlock = onViewChangedBody.blockVirtual();
 		onViewChangedBodyAfterInjectionBlock = onViewChangedBody.blockVirtual();
-		onViewChangedHasViewsParam = onViewChanged.param(HasViews.class, "hasViews");
+		onViewChangedHasViewsParam = onViewChangedMethod.param(HasViews.class, "hasViews");
 		AbstractJClass notifierClass = getJClass(OnViewChangedNotifier.class);
 		getInitBodyInjectionBlock().add(notifierClass.staticInvoke("registerOnViewChangedListener").arg(_this()));
 	}
@@ -207,17 +214,17 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	}
 
 	public JMethod getFindNativeFragmentById() {
-		if (findNativeFragmentById == null) {
+		if (findNativeFragmentByIdMethod == null) {
 			setFindNativeFragmentById();
 		}
-		return findNativeFragmentById;
+		return findNativeFragmentByIdMethod;
 	}
 
 	protected void setFindNativeFragmentById() {
-		findNativeFragmentById = getGeneratedClass().method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentById");
-		JVar idParam = findNativeFragmentById.param(getCodeModel().INT, "id");
+		findNativeFragmentByIdMethod = getGeneratedClass().method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentById");
+		JVar idParam = findNativeFragmentByIdMethod.param(getCodeModel().INT, "id");
 
-		JBlock body = findNativeFragmentById.body();
+		JBlock body = findNativeFragmentByIdMethod.body();
 
 		body._if(getContextRef()._instanceof(getClasses().ACTIVITY).not())._then()._return(_null());
 
@@ -227,21 +234,21 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	}
 
 	public JMethod getFindSupportFragmentById() {
-		if (findSupportFragmentById == null) {
+		if (findSupportFragmentByIdMethod == null) {
 			setFindSupportFragmentById();
 		}
-		return findSupportFragmentById;
+		return findSupportFragmentByIdMethod;
 	}
 
 	protected void setFindSupportFragmentById() {
 		if (getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.ANDROIDX_FRAGMENT) == null) {
-			findSupportFragmentById = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentById");
+			findSupportFragmentByIdMethod = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentById");
 		} else {
-			findSupportFragmentById = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentById");
+			findSupportFragmentByIdMethod = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentById");
 		}
-		JVar idParam = findSupportFragmentById.param(getCodeModel().INT, "id");
+		JVar idParam = findSupportFragmentByIdMethod.param(getCodeModel().INT, "id");
 
-		JBlock body = findSupportFragmentById.body();
+		JBlock body = findSupportFragmentByIdMethod.body();
 
 		AbstractJClass fragmentActivity = getFragmentActivity();
 		body._if(getContextRef()._instanceof(fragmentActivity).not())._then()._return(_null());
@@ -261,17 +268,17 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	}
 
 	public JMethod getFindNativeFragmentByTag() {
-		if (findNativeFragmentByTag == null) {
+		if (findNativeFragmentByTagMethod == null) {
 			setFindNativeFragmentByTag();
 		}
-		return findNativeFragmentByTag;
+		return findNativeFragmentByTagMethod;
 	}
 
 	protected void setFindNativeFragmentByTag() {
-		findNativeFragmentByTag = getGeneratedClass().method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentByTag");
-		JVar tagParam = findNativeFragmentByTag.param(getClasses().STRING, "tag");
+		findNativeFragmentByTagMethod = getGeneratedClass().method(PRIVATE, getClasses().FRAGMENT, "findNativeFragmentByTag");
+		JVar tagParam = findNativeFragmentByTagMethod.param(getClasses().STRING, "tag");
 
-		JBlock body = findNativeFragmentByTag.body();
+		JBlock body = findNativeFragmentByTagMethod.body();
 
 		body._if(getContextRef()._instanceof(getClasses().ACTIVITY).not())._then()._return(_null());
 
@@ -281,21 +288,21 @@ public abstract class EComponentWithViewSupportHolder extends EComponentHolder i
 	}
 
 	public JMethod getFindSupportFragmentByTag() {
-		if (findSupportFragmentByTag == null) {
+		if (findSupportFragmentByTagMethod == null) {
 			setFindSupportFragmentByTag();
 		}
-		return findSupportFragmentByTag;
+		return findSupportFragmentByTagMethod;
 	}
 
 	protected void setFindSupportFragmentByTag() {
 		if (getProcessingEnvironment().getElementUtils().getTypeElement(CanonicalNameConstants.ANDROIDX_FRAGMENT) == null) {
-			findSupportFragmentByTag = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentByTag");
+			findSupportFragmentByTagMethod = getGeneratedClass().method(PRIVATE, getClasses().SUPPORT_V4_FRAGMENT, "findSupportFragmentByTag");
 		} else {
-			findSupportFragmentByTag = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentByTag");
+			findSupportFragmentByTagMethod = getGeneratedClass().method(PRIVATE, getClasses().ANDROIDX_FRAGMENT, "findSupportFragmentByTag");
 		}
-		JVar tagParam = findSupportFragmentByTag.param(getClasses().STRING, "tag");
+		JVar tagParam = findSupportFragmentByTagMethod.param(getClasses().STRING, "tag");
 
-		JBlock body = findSupportFragmentByTag.body();
+		JBlock body = findSupportFragmentByTagMethod.body();
 
 		AbstractJClass fragmentActivity = getFragmentActivity();
 		body._if(getContextRef()._instanceof(fragmentActivity).not())._then()._return(_null());

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EFragmentHolder.java
@@ -57,6 +57,7 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 
 	private JFieldVar contentView;
 	private JFieldVar viewDestroyedField;
+	private JMethod onCreateViewMethod;
 	private JBlock setContentViewBlock;
 	private JVar inflater;
 	private JVar container;
@@ -70,21 +71,34 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	private OnActivityResultDelegate onActivityResultDelegate;
 	private ReceiverRegistrationDelegate<EFragmentHolder> receiverRegistrationDelegate;
 	private PreferencesDelegate preferencesDelegate;
+	private JMethod onCreateOptionsMenuMethod;
 	private JBlock onCreateOptionsMenuMethodBody;
 	private JBlock onCreateOptionsMenuMethodInflateBody;
 	private JVar onCreateOptionsMenuMenuInflaterVar;
 	private JVar onCreateOptionsMenuMenuParam;
+	private JMethod onOptionsItemSelectedMethod;
 	private JVar onOptionsItemSelectedItem;
 	private JVar onOptionsItemSelectedItemId;
 	private JBlock onOptionsItemSelectedMiddleBlock;
+	private JMethod onViewCreatedMethod;
+	private JMethod findViewByIdMethod;
+	private JMethod onCreateMethod;
 	private JBlock onCreateAfterSuperBlock;
+	private JMethod onDestroyMethod;
 	private JBlock onDestroyBeforeSuperBlock;
+	private JMethod onStartMethod;
 	private JBlock onStartAfterSuperBlock;
+	private JMethod onStopMethod;
 	private JBlock onStopBeforeSuperBlock;
+	private JMethod onResumeMethod;
 	private JBlock onResumeAfterSuperBlock;
+	private JMethod onPauseMethod;
 	private JBlock onPauseBeforeSuperBlock;
+	private JMethod onAttachMethod;
 	private JBlock onAttachAfterSuperBlock;
+	private JMethod onDetachMethod;
 	private JBlock onDetachBeforeSuperBlock;
+	private JMethod onDestroyViewMethod;
 	private JBlock onDestroyViewAfterSuperBlock;
 
 	public EFragmentHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement) throws Exception {
@@ -100,25 +114,25 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnCreate() {
-		JMethod onCreate = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
-		onCreate.annotate(Override.class);
-		JVar onCreateSavedInstanceState = onCreate.param(getClasses().BUNDLE, "savedInstanceState");
-		JBlock onCreateBody = onCreate.body();
+		onCreateMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
+		onCreateMethod.annotate(Override.class);
+		JVar onCreateSavedInstanceState = onCreateMethod.param(getClasses().BUNDLE, "savedInstanceState");
+		JBlock onCreateBody = onCreateMethod.body();
 
 		JVar previousNotifier = viewNotifierHelper.replacePreviousNotifier(onCreateBody);
 		onCreateBody.add(JExpr.invoke(getInit()).arg(onCreateSavedInstanceState));
-		onCreateBody.add(_super().invoke(onCreate).arg(onCreateSavedInstanceState));
+		onCreateBody.add(_super().invoke(onCreateMethod).arg(onCreateSavedInstanceState));
 		onCreateAfterSuperBlock = onCreateBody.blockSimple();
 		viewNotifierHelper.resetPreviousNotifier(onCreateBody, previousNotifier);
 	}
 
 	private void setOnViewCreated() {
-		JMethod onViewCreated = generatedClass.method(PUBLIC, getCodeModel().VOID, "onViewCreated");
-		onViewCreated.annotate(Override.class);
-		JVar view = onViewCreated.param(getClasses().VIEW, "view");
-		JVar savedInstanceState = onViewCreated.param(getClasses().BUNDLE, "savedInstanceState");
-		JBlock onViewCreatedBody = onViewCreated.body();
-		onViewCreatedBody.add(_super().invoke(onViewCreated).arg(view).arg(savedInstanceState));
+		JMethod onViewCreatedMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onViewCreated");
+		onViewCreatedMethod.annotate(Override.class);
+		JVar view = onViewCreatedMethod.param(getClasses().VIEW, "view");
+		JVar savedInstanceState = onViewCreatedMethod.param(getClasses().BUNDLE, "savedInstanceState");
+		JBlock onViewCreatedBody = onViewCreatedMethod.body();
+		onViewCreatedBody.add(_super().invoke(onViewCreatedMethod).arg(view).arg(savedInstanceState));
 		viewNotifierHelper.invokeViewChanged(onViewCreatedBody);
 	}
 
@@ -161,27 +175,27 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnCreateOptionsMenu() {
-		JMethod method = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreateOptionsMenu");
-		method.annotate(Override.class);
-		JBlock methodBody = method.body();
-		onCreateOptionsMenuMenuParam = method.param(getClasses().MENU, "menu");
-		onCreateOptionsMenuMenuInflaterVar = method.param(getClasses().MENU_INFLATER, "inflater");
+		onCreateOptionsMenuMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreateOptionsMenu");
+		onCreateOptionsMenuMethod.annotate(Override.class);
+		JBlock methodBody = onCreateOptionsMenuMethod.body();
+		onCreateOptionsMenuMenuParam = onCreateOptionsMenuMethod.param(getClasses().MENU, "menu");
+		onCreateOptionsMenuMenuInflaterVar = onCreateOptionsMenuMethod.param(getClasses().MENU_INFLATER, "inflater");
 		onCreateOptionsMenuMethodInflateBody = methodBody.blockSimple();
 		onCreateOptionsMenuMethodBody = methodBody.blockSimple();
-		methodBody.add(_super().invoke(method).arg(onCreateOptionsMenuMenuParam).arg(onCreateOptionsMenuMenuInflaterVar));
+		methodBody.add(_super().invoke(onCreateOptionsMenuMethod).arg(onCreateOptionsMenuMenuParam).arg(onCreateOptionsMenuMenuInflaterVar));
 
 		getInitBody().add(JExpr.invoke("setHasOptionsMenu").arg(JExpr.TRUE));
 	}
 
 	private void setOnOptionsItemSelected() {
-		JMethod method = generatedClass.method(JMod.PUBLIC, getCodeModel().BOOLEAN, "onOptionsItemSelected");
-		method.annotate(Override.class);
-		JBlock methodBody = method.body();
-		onOptionsItemSelectedItem = method.param(getClasses().MENU_ITEM, "item");
+		onOptionsItemSelectedMethod = generatedClass.method(JMod.PUBLIC, getCodeModel().BOOLEAN, "onOptionsItemSelected");
+		onOptionsItemSelectedMethod.annotate(Override.class);
+		JBlock methodBody = onOptionsItemSelectedMethod.body();
+		onOptionsItemSelectedItem = onOptionsItemSelectedMethod.param(getClasses().MENU_ITEM, "item");
 		onOptionsItemSelectedItemId = methodBody.decl(getCodeModel().INT, "itemId_", onOptionsItemSelectedItem.invoke("getItemId"));
 		onOptionsItemSelectedMiddleBlock = methodBody.blockSimple();
 
-		methodBody._return(invoke(_super(), method).arg(onOptionsItemSelectedItem));
+		methodBody._return(invoke(_super(), onOptionsItemSelectedMethod).arg(onOptionsItemSelectedItem));
 	}
 
 	@Override
@@ -196,8 +210,8 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
-		init.param(getClasses().BUNDLE, "savedInstanceState");
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod.param(getClasses().BUNDLE, "savedInstanceState");
 	}
 
 	public JFieldVar getContentView() {
@@ -231,20 +245,20 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnCreateView() {
-		JMethod onCreateView = generatedClass.method(PUBLIC, getClasses().VIEW, "onCreateView");
-		onCreateView.annotate(Override.class);
+		onCreateViewMethod = generatedClass.method(PUBLIC, getClasses().VIEW, "onCreateView");
+		onCreateViewMethod.annotate(Override.class);
 
-		inflater = onCreateView.param(getClasses().LAYOUT_INFLATER, "inflater");
-		container = onCreateView.param(getClasses().VIEW_GROUP, "container");
+		inflater = onCreateViewMethod.param(getClasses().LAYOUT_INFLATER, "inflater");
+		container = onCreateViewMethod.param(getClasses().VIEW_GROUP, "container");
 
-		JVar savedInstanceState = onCreateView.param(getClasses().BUNDLE, "savedInstanceState");
+		JVar savedInstanceState = onCreateViewMethod.param(getClasses().BUNDLE, "savedInstanceState");
 
 		boolean forceInjection = getAnnotatedElement().getAnnotation(EFragment.class).forceLayoutInjection();
 
-		JBlock body = onCreateView.body();
+		JBlock body = onCreateViewMethod.body();
 
 		if (!forceInjection) {
-			body.assign(contentView, _super().invoke(onCreateView).arg(inflater).arg(container).arg(savedInstanceState));
+			body.assign(contentView, _super().invoke(onCreateViewMethod).arg(inflater).arg(container).arg(savedInstanceState));
 		}
 
 		setContentViewBlock = body.blockSimple();
@@ -253,14 +267,21 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnDestroyView() {
-		JMethod onDestroyView = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroyView");
-		onDestroyView.annotate(Override.class);
-		JBlock body = onDestroyView.body();
-		body.invoke(_super(), onDestroyView);
+		onDestroyViewMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroyView");
+		onDestroyViewMethod.annotate(Override.class);
+		JBlock body = onDestroyViewMethod.body();
+		body.invoke(_super(), onDestroyViewMethod);
 		body.assign(contentView, _null());
 		onDestroyViewAfterSuperBlock = body.blockSimple();
 	}
 
+	public JMethod getOnDestroyView() {
+		if (onDestroyViewMethod == null) {
+			setContentViewRelatedMethods();
+		}
+		return onDestroyViewMethod;
+	}
+	
 	public JBlock getOnDestroyViewAfterSuperBlock() {
 		if (onDestroyViewAfterSuperBlock == null) {
 			setContentViewRelatedMethods();
@@ -274,62 +295,69 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	}
 
 	private void setOnStart() {
-		JMethod onStart = generatedClass.method(PUBLIC, getCodeModel().VOID, "onStart");
-		onStart.annotate(Override.class);
-		JBlock onStartBody = onStart.body();
-		onStartBody.invoke(_super(), onStart);
+		onStartMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onStart");
+		onStartMethod.annotate(Override.class);
+		JBlock onStartBody = onStartMethod.body();
+		onStartBody.invoke(_super(), onStartMethod);
 		onStartAfterSuperBlock = onStartBody.blockSimple();
 	}
 
 	private void setOnAttach() {
-		JMethod onAttach = generatedClass.method(PUBLIC, getCodeModel().VOID, "onAttach");
-		onAttach.annotate(Override.class);
-		JVar activityParam = onAttach.param(getClasses().ACTIVITY, "activity");
-		JBlock onAttachBody = onAttach.body();
-		onAttachBody.add(_super().invoke(onAttach).arg(activityParam));
+		JMethod onAttachMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onAttach");
+		onAttachMethod.annotate(Override.class);
+		JVar activityParam = onAttachMethod.param(getClasses().ACTIVITY, "activity");
+		JBlock onAttachBody = onAttachMethod.body();
+		onAttachBody.add(_super().invoke(onAttachMethod).arg(activityParam));
 		onAttachAfterSuperBlock = onAttachBody.blockSimple();
 	}
 
 	private void setOnResume() {
-		JMethod onResume = generatedClass.method(PUBLIC, getCodeModel().VOID, "onResume");
-		onResume.annotate(Override.class);
-		JBlock onResumeBody = onResume.body();
-		onResumeBody.invoke(_super(), onResume);
+		onResumeMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onResume");
+		onResumeMethod.annotate(Override.class);
+		JBlock onResumeBody = onResumeMethod.body();
+		onResumeBody.invoke(_super(), onResumeMethod);
 		onResumeAfterSuperBlock = onResumeBody.blockSimple();
 	}
 
 	private void setOnPause() {
-		JMethod onPause = generatedClass.method(PUBLIC, getCodeModel().VOID, "onPause");
-		onPause.annotate(Override.class);
-		JBlock onPauseBody = onPause.body();
+		onPauseMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onPause");
+		onPauseMethod.annotate(Override.class);
+		JBlock onPauseBody = onPauseMethod.body();
 		onPauseBeforeSuperBlock = onPauseBody.blockSimple();
-		onPauseBody.invoke(_super(), onPause);
+		onPauseBody.invoke(_super(), onPauseMethod);
 	}
 
 	private void setOnDetach() {
-		JMethod onDetach = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDetach");
-		onDetach.annotate(Override.class);
-		JBlock onDetachBody = onDetach.body();
+		onDetachMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDetach");
+		onDetachMethod.annotate(Override.class);
+		JBlock onDetachBody = onDetachMethod.body();
 		onDetachBeforeSuperBlock = onDetachBody.blockSimple();
-		onDetachBody.invoke(_super(), onDetach);
+		onDetachBody.invoke(_super(), onDetachMethod);
 	}
 
 	private void setOnStop() {
-		JMethod onStop = generatedClass.method(PUBLIC, getCodeModel().VOID, "onStop");
-		onStop.annotate(Override.class);
-		JBlock onStopBody = onStop.body();
+		onStopMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onStop");
+		onStopMethod.annotate(Override.class);
+		JBlock onStopBody = onStopMethod.body();
 		onStopBeforeSuperBlock = onStopBody.blockSimple();
-		onStopBody.invoke(_super(), onStop);
+		onStopBody.invoke(_super(), onStopMethod);
 	}
 
 	private void setOnDestroy() {
-		JMethod onDestroy = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroy");
-		onDestroy.annotate(Override.class);
-		JBlock onDestroyBody = onDestroy.body();
+		onDestroyMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroy");
+		onDestroyMethod.annotate(Override.class);
+		JBlock onDestroyBody = onDestroyMethod.body();
 		onDestroyBeforeSuperBlock = onDestroyBody.blockSimple();
-		onDestroyBody.invoke(_super(), onDestroy);
+		onDestroyBody.invoke(_super(), onDestroyMethod);
 	}
 
+	public JMethod getOnCreateView() {
+		if (onCreateViewMethod == null) {
+			setOnCreateView();
+		}
+		return onCreateViewMethod;
+	}
+	
 	public JBlock getSetContentViewBlock() {
 		if (setContentViewBlock == null) {
 			setOnCreateView();
@@ -414,6 +442,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return instanceStateDelegate.getRestoreStateBundleParam();
 	}
 
+	public JMethod getOnCreateOptionsMenu() {
+		if (onCreateOptionsMenuMethod == null) {
+			setOnCreateOptionsMenu();
+		}
+		return onCreateOptionsMenuMethod;
+	}
+	
 	@Override
 	public JBlock getOnCreateOptionsMenuMethodBody() {
 		if (onCreateOptionsMenuMethodBody == null) {
@@ -446,6 +481,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onCreateOptionsMenuMenuParam;
 	}
 
+	public JMethod getOnOptionsItemSelected() {
+		if (onOptionsItemSelectedMethod == null) {
+			setOnOptionsItemSelected();
+		}
+		return onOptionsItemSelectedMethod;
+	}
+	
 	@Override
 	public JVar getOnOptionsItemSelectedItem() {
 		if (onOptionsItemSelectedItem == null) {
@@ -494,6 +536,20 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 	public JFieldVar getIntentFilterField(IntentFilterData intentFilterData) {
 		return receiverRegistrationDelegate.getIntentFilterField(intentFilterData);
 	}
+	
+	public JMethod getOnViewCreated() {
+		if (onViewCreatedMethod == null) {
+			setOnViewCreated();
+		}
+		return onViewCreatedMethod;
+	}
+	
+	public JMethod getOnCreate() {
+		if (onCreateMethod == null) {
+			setOnCreate();
+		}
+		return onCreateMethod;
+	}
 
 	@Override
 	public JBlock getStartLifecycleAfterSuperBlock() {
@@ -513,6 +569,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onCreateAfterSuperBlock;
 	}
 
+	public JMethod getOnDestroyMethod() {
+		if (onDestroyMethod == null) {
+			setOnDestroy();
+		}
+		return onDestroyMethod;
+	}
+	
 	@Override
 	public JBlock getOnDestroyBeforeSuperBlock() {
 		if (onDestroyBeforeSuperBlock == null) {
@@ -521,6 +584,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onDestroyBeforeSuperBlock;
 	}
 
+	public JMethod getOnStart() {
+		if (onStartMethod == null) {
+			setOnStart();
+		}
+		return onStartMethod;
+	}
+	
 	@Override
 	public JBlock getOnStartAfterSuperBlock() {
 		if (onStartAfterSuperBlock == null) {
@@ -529,12 +599,26 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onStartAfterSuperBlock;
 	}
 
+	public JMethod getOnStop() {
+		if (onStopMethod == null) {
+			setOnStop();
+		}
+		return onStopMethod;
+	}
+	
 	@Override
 	public JBlock getOnStopBeforeSuperBlock() {
 		if (onStopBeforeSuperBlock == null) {
 			setOnStop();
 		}
 		return onStopBeforeSuperBlock;
+	}
+	
+	public JMethod getOnResumeMethod() {
+		if (onResumeMethod == null) {
+			setOnResume();
+		}
+		return onResumeMethod;
 	}
 
 	@Override
@@ -545,6 +629,13 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onResumeAfterSuperBlock;
 	}
 
+	public JMethod getOnPauseMethod() {
+		if (onPauseMethod == null) {
+			setOnPause();
+		}
+		return onPauseMethod;
+	}
+	
 	@Override
 	public JBlock getOnPauseBeforeSuperBlock() {
 		if (onPauseBeforeSuperBlock == null) {
@@ -553,11 +644,25 @@ public class EFragmentHolder extends EComponentWithViewSupportHolder
 		return onPauseBeforeSuperBlock;
 	}
 
+	public JMethod getOnAttach() {
+		if (onAttachMethod == null) {
+			setOnAttach();
+		}
+		return onAttachMethod;
+	}
+
 	public JBlock getOnAttachAfterSuperBlock() {
 		if (onAttachAfterSuperBlock == null) {
 			setOnAttach();
 		}
 		return onAttachAfterSuperBlock;
+	}
+	
+	public void setOnDetachMethod(JMethod onDetachMethod) {
+		if (onDetachMethod == null) {
+			setOnDetach();
+		}
+		this.onDetachMethod = onDetachMethod;
 	}
 
 	public JBlock getOnDetachBeforeSuperBlock() {

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EProviderHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EProviderHolder.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2010-2016 eBusiness Information, Excilys Group
+ * Copyright (C) 2016-2019 the AndroidAnnotations project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +31,9 @@ import com.helger.jcodemodel.JMethod;
 
 public class EProviderHolder extends EComponentHolder {
 
+	private JMethod onCreateMethod;
+	private JBlock onCreateBody;
+
 	public EProviderHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement) throws Exception {
 		super(environment, annotatedElement);
 	}
@@ -41,15 +45,23 @@ public class EProviderHolder extends EComponentHolder {
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 		createOnCreate();
 	}
 
 	private void createOnCreate() {
-		JMethod onCreate = generatedClass.method(PUBLIC, getCodeModel().BOOLEAN, "onCreate");
-		onCreate.annotate(Override.class);
-		JBlock onCreateBody = onCreate.body();
+		onCreateMethod = generatedClass.method(PUBLIC, getCodeModel().BOOLEAN, "onCreate");
+		onCreateMethod.annotate(Override.class);
+		onCreateBody = onCreateMethod.body();
 		onCreateBody.invoke(getInit());
-		onCreateBody._return(invoke(_super(), onCreate));
+		onCreateBody._return(invoke(_super(), onCreateMethod));
+	}
+
+	public JMethod getOnCreate() {
+		return onCreateMethod;
+	}
+
+	public JBlock getOnCreateBody() {
+		return onCreateBody;
 	}
 }

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EReceiverHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EReceiverHolder.java
@@ -32,12 +32,12 @@ import com.helger.jcodemodel.JVar;
 
 public class EReceiverHolder extends EComponentHolder {
 
+	private JMethod onReceiveMethod;
 	private JBlock onReceiveBody;
 	private JVar onReceiveIntentAction;
 	private JVar onReceiveIntentDataScheme;
 	private JVar onReceiveIntent;
 	private JVar onReceiveContext;
-	private JMethod onReceiveMethod;
 
 	public EReceiverHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement) throws Exception {
 		super(environment, annotatedElement);
@@ -45,15 +45,15 @@ public class EReceiverHolder extends EComponentHolder {
 
 	@Override
 	protected void setContextRef() {
-		if (init == null) {
+		if (initMethod == null) {
 			setInit();
 		}
 	}
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
-		contextRef = init.param(getClasses().CONTEXT, "context");
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		contextRef = initMethod.param(getClasses().CONTEXT, "context");
 		if (onReceiveMethod == null) {
 			createOnReceive();
 		}

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EServiceHolder.java
@@ -41,6 +41,12 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 	private JDefinedClass intentBuilderClass;
 	private ReceiverRegistrationDelegate<EServiceHolder> receiverRegistrationDelegate;
 	private JBlock onCreateAfterSuperBlock;
+	
+	private JMethod onCreateMethod;
+	private JBlock onCreateBody;
+	
+	private JMethod onDestroyMethod;
+	private JBlock onDestroyBody;
 	private JBlock onDestroyBeforeSuperBlock;
 
 	public EServiceHolder(AndroidAnnotationsEnvironment environment, TypeElement annotatedElement, AndroidManifest androidManifest) throws Exception {
@@ -62,25 +68,47 @@ public class EServiceHolder extends EComponentHolder implements HasIntentBuilder
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 		setOnCreate();
 	}
 
+	public JMethod getOnCreate() {
+		return onCreateMethod;
+	}
+	
+	public JBlock getOnCreateBody() {
+		return onCreateBody;
+	}
+	
 	private void setOnCreate() {
-		JMethod onCreate = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
-		onCreate.annotate(Override.class);
-		JBlock onCreateBody = onCreate.body();
+		onCreateMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onCreate");
+		onCreateMethod.annotate(Override.class);
+		onCreateBody = onCreateMethod.body();
 		onCreateBody.invoke(getInit());
-		onCreateBody.invoke(JExpr._super(), onCreate);
+		onCreateBody.invoke(JExpr._super(), onCreateMethod);
 		onCreateAfterSuperBlock = onCreateBody.blockVirtual();
 	}
 
+	public JMethod getOnDestroy() {
+		if (onDestroyMethod == null) {
+			setOnDestroy();
+		}
+		return onDestroyMethod;
+	}
+	
+	public JBlock getOnDestroyBody() {
+		if (onDestroyBody == null) {
+			setOnDestroy();
+		}
+		return onDestroyBody;
+	}
+	
 	private void setOnDestroy() {
-		JMethod onDestroy = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroy");
-		onDestroy.annotate(Override.class);
-		JBlock onDestroyBody = onDestroy.body();
+		onDestroyMethod = generatedClass.method(PUBLIC, getCodeModel().VOID, "onDestroy");
+		onDestroyMethod.annotate(Override.class);
+		onDestroyBody = onDestroyMethod.body();
 		onDestroyBeforeSuperBlock = onDestroyBody.blockSimple();
-		onDestroyBody.invoke(JExpr._super(), onDestroy);
+		onDestroyBody.invoke(JExpr._super(), onDestroyMethod);
 	}
 
 	@Override

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/holder/EViewHolder.java
@@ -125,7 +125,7 @@ public class EViewHolder extends EComponentWithViewSupportHolder implements HasI
 
 	@Override
 	protected void setInit() {
-		init = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
+		initMethod = generatedClass.method(PRIVATE, getCodeModel().VOID, "init" + generationSuffix());
 		viewNotifierHelper.wrapInitWithNotifier();
 	}
 


### PR DESCRIPTION
This PR creates a more homogeneous naming for the `JMethod` fields (before some of then ended with "Method" and other not, now all of them end with "Method" suffix). 

It also exposes more of these methods in the holder through a getter, which is useful for Plugins which need to modify different parts of a generated class. 