### PR TITLE
 Support Android Gradle Plugin 3.5.0-beta03 and 3.6.0-alpha01

### DIFF
--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -126,7 +126,7 @@ public class AndroidManifestFinder {
 		return findManifestInKnownPathsStartingFromGenFolder(holder.sourcesGenerationFolder.getAbsolutePath());
 	}
 
-	File findManifestInKnownPathsStartingFromGenFolder(String sourcesGenerationFolder) throws FileNotFoundException {
+	File findManifestInKnownPathsStartingFromGenFolder(String sourcesGenerationFolder) {
 		Iterable<AndroidManifestFinderStrategy> strategies = Arrays.asList(new GradleAndroidManifestFinderStrategy(environment, sourcesGenerationFolder),
 				new MavenAndroidManifestFinderStrategy(sourcesGenerationFolder), new EclipseAndroidManifestFinderStrategy(sourcesGenerationFolder));
 

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -128,7 +128,8 @@ public class AndroidManifestFinder {
 
 	File findManifestInKnownPathsStartingFromGenFolder(String sourcesGenerationFolder) {
 		Iterable<AndroidManifestFinderStrategy> strategies = Arrays.asList(new GradleAndroidManifestFinderStrategy(environment, sourcesGenerationFolder),
-				new MavenAndroidManifestFinderStrategy(sourcesGenerationFolder), new EclipseAndroidManifestFinderStrategy(sourcesGenerationFolder));
+				new LegacyGradleAndroidManifestFinderStrategy(environment, sourcesGenerationFolder), new MavenAndroidManifestFinderStrategy(sourcesGenerationFolder),
+				new EclipseAndroidManifestFinderStrategy(sourcesGenerationFolder));
 
 		AndroidManifestFinderStrategy applyingStrategy = null;
 
@@ -181,9 +182,36 @@ public class AndroidManifestFinder {
 		abstract Iterable<String> possibleLocations();
 	}
 
-	private static class GradleAndroidManifestFinderStrategy extends AndroidManifestFinderStrategy {
+	private static class GradleAndroidManifestFinderStrategy extends AbstractGradleAndroidManifestFinderStrategy {
 
-		static final Pattern GRADLE_GEN_FOLDER = Pattern.compile("^(.*?)build[\\\\/]generated[\\\\/]source[\\\\/](k?apt)(.*)$");
+		private static final Pattern GRADLE_GEN_FOLDER = Pattern.compile("^(.*?)build[\\\\/]generated[\\\\/]ap_generated_sources[\\\\/](.*)[\\\\/]out(.*)$");
+
+		GradleAndroidManifestFinderStrategy(AndroidAnnotationsEnvironment environment, String sourceFolder) {
+			super(GRADLE_GEN_FOLDER, environment, sourceFolder);
+		}
+
+		@Override
+		protected String getGradleVariant() {
+			return matcher.group(2);
+		}
+	}
+
+	private static class LegacyGradleAndroidManifestFinderStrategy extends AbstractGradleAndroidManifestFinderStrategy {
+
+		private static final Pattern GRADLE_GEN_FOLDER = Pattern.compile("^(.*?)build[\\\\/]generated[\\\\/]source[\\\\/](k?apt)(.*)$");
+
+		LegacyGradleAndroidManifestFinderStrategy(AndroidAnnotationsEnvironment environment, String sourceFolder) {
+			super(GRADLE_GEN_FOLDER, environment, sourceFolder);
+		}
+
+		@Override
+		protected String getGradleVariant() {
+			return matcher.group(3).substring(1);
+		}
+	}
+
+	private static abstract class AbstractGradleAndroidManifestFinderStrategy extends AndroidManifestFinderStrategy {
+
 		static final Pattern OUTPUT_JSON_PATTERN = Pattern.compile(".*,\"path\":\"(.*?)\",.*");
 
 		private static final List<String> SUPPORTED_ABI_SPLITS = Arrays.asList("arm64-v8a", "armeabi", "armeabi-v7a", "mips", "mips64", "x86", "x86_64");
@@ -193,22 +221,26 @@ public class AndroidManifestFinder {
 
 		private final AndroidAnnotationsEnvironment environment;
 
-		GradleAndroidManifestFinderStrategy(AndroidAnnotationsEnvironment environment, String sourceFolder) {
-			super("Gradle", GRADLE_GEN_FOLDER, sourceFolder);
+		AbstractGradleAndroidManifestFinderStrategy(Pattern pattern, AndroidAnnotationsEnvironment environment, String sourceFolder) {
+			super("Gradle", pattern, sourceFolder);
 			this.environment = environment;
 		}
 
+		protected String getPath() {
+			return matcher.group(1);
+		}
+
+		protected abstract String getGradleVariant();
+
 		@Override
 		Iterable<String> possibleLocations() {
-			String path = matcher.group(1);
-			String mode = matcher.group(2);
-			String gradleVariant = matcher.group(3);
-			String variantPart = gradleVariant.substring(1);
+			String path = getPath();
+			String gradleVariant = getGradleVariant();
 
 			List<String> possibleLocations = new ArrayList<>();
-			findPossibleLocationsV32(path, variantPart, possibleLocations);
+			findPossibleLocationsV32(path, gradleVariant, possibleLocations);
 			for (String directory : Arrays.asList("build/intermediates/manifests/full", "build/intermediates/bundles", "build/intermediates/manifests/aapt")) {
-				findPossibleLocations(path, directory, variantPart, possibleLocations);
+				findPossibleLocations(path, directory, gradleVariant, possibleLocations);
 			}
 
 			return updateLocations(path, possibleLocations);

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/main/java/org/androidannotations/internal/helper/AndroidManifestFinder.java
@@ -220,9 +220,9 @@ public class AndroidManifestFinder {
 				String expectedLocation = path + "/" + location;
 				File file = new File(expectedLocation + "/output.json");
 				if (file.exists()) {
-					Matcher matcher = OUTPUT_JSON_PATTERN.matcher(readJsonFromFile(file));
-					if (matcher.matches()) {
-						String relativeManifestPath = matcher.group(1);
+					Matcher jsonMatcher = OUTPUT_JSON_PATTERN.matcher(readJsonFromFile(file));
+					if (jsonMatcher.matches()) {
+						String relativeManifestPath = jsonMatcher.group(1);
 						File manifestFile = new File(expectedLocation + "/" + relativeManifestPath);
 						String manifestDirectory = manifestFile.getParentFile().getAbsolutePath();
 						knownLocations.add(manifestDirectory.substring(path.length()));

--- a/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
+++ b/AndroidAnnotations/androidannotations-core/androidannotations/src/test/java/org/androidannotations/internal/helper/AndroidManifestFinderTest.java
@@ -90,6 +90,17 @@ public class AndroidManifestFinderTest {
 		Object[] gradleManifestFoundInMergedManifestsWithBothSplitV33 = { GRADLE_GEN_FOLDER, "build/intermediates/merged_manifests/debug/x86/hdpi", true };
 		Object[] gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV33 = { GRADLE_FLAVOR_GEN_FOLDER, "build/intermediates/merged_manifests/flavorDebug/x86/hdpi", true };
 
+		Object[] gradleManifestFoundInMergedManifestsV35 = { "build/generated/ap_generated_sources/debug/out", "build/intermediates/merged_manifests/debug/", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplitV35 = { "build/generated/ap_generated_sources/debug/out", "build/intermediates/merged_manifests/debug/x86", true };
+		Object[] gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavorV35 = { "build/generated/ap_generated_sources/flavorDebug/out", "build/intermediates/merged_manifests/flavorDebug/x86",
+				true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplitV35 = { "build/generated/ap_generated_sources/debug/out", "build/intermediates/merged_manifests/debug/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavorV35 = { "build/generated/ap_generated_sources/flavorDebug/out", "build/intermediates/merged_manifests/flavorDebug/hdpi",
+				true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplitV35 = { "build/generated/ap_generated_sources/debug/out", "build/intermediates/merged_manifests/debug/x86/hdpi", true };
+		Object[] gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV35 = { "build/generated/ap_generated_sources/flavorDebug/out", "build/intermediates/merged_manifests/flavorDebug/x86/hdpi",
+				true };
+
 		Object[] gradleKotlinManifestFoundInManifests = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/full/debug", true };
 		Object[] gradleKotlinManifestFoundInBundles = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/bundles/debug", true };
 		Object[] gradleKotlinManifestFoundInManifestsAapt = { GRADLE_KOTLIN_GEN_FOLDER, "build/intermediates/manifests/aapt/debug", true };
@@ -145,17 +156,19 @@ public class AndroidManifestFinderTest {
 				gradleManifestFoundInMergedManifestsWithBothSplit, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleManifestFoundInMergedManifestsV33,
 				gradleManifestFoundInMergedManifestsWithAbiSplitV33, gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33, gradleManifestFoundInMergedManifestsWithDensitySplitV33,
 				gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33, gradleManifestFoundInMergedManifestsWithBothSplitV33, gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV33,
-				gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt, gradleKotlinManifestFoundInManifestsWithFlavor,
-				gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor, gradleKotlinManifestFoundInManifestsWithAbiSplit,
-				gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInManifestsWithDensitySplit, gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor,
-				gradleKotlinManifestFoundInManifestsWithBothSplit, gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifests,
-				gradleKotlinManifestFoundInMergedManifestsWithAbiSplit, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithDensitySplit,
-				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsWithBothSplit,
-				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsV33, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitV33,
-				gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33, gradleKotlinManifestFoundInMergedManifestsWithDensitySplitV33,
-				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33, gradleKotlinManifestFoundInMergedManifestsWithBothSplitV33,
-				gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavorV33, mavenManifestFoundInTarget, mavenManifestFoundInSrc, mavenManifestFoundInRoot, eclipseManifestFound,
-				gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound, noGeneratedFolderFound);
+				gradleManifestFoundInMergedManifestsV35, gradleManifestFoundInMergedManifestsWithAbiSplitV35, gradleManifestFoundInMergedManifestsWithAbiSplitAndFlavorV35,
+				gradleManifestFoundInMergedManifestsWithDensitySplitV35, gradleManifestFoundInMergedManifestsWithDensitySplitAndFlavorV35, gradleManifestFoundInMergedManifestsWithBothSplitV35,
+				gradleManifestFoundInMergedManifestsWithBothSplitAndFlavorV35, gradleKotlinManifestFoundInManifests, gradleKotlinManifestFoundInBundles, gradleKotlinManifestFoundInManifestsAapt,
+				gradleKotlinManifestFoundInManifestsWithFlavor, gradleKotlinManifestFoundInBundlesWithFlavor, gradleKotlinManifestFoundInManifestsAaptWithFlavor,
+				gradleKotlinManifestFoundInManifestsWithAbiSplit, gradleKotlinManifestFoundInManifestsWithAbiSplitAndFlavor, gradleKotlinManifestFoundInManifestsWithDensitySplit,
+				gradleKotlinManifestFoundInManifestsWithDensitySplitAndFlavor, gradleKotlinManifestFoundInManifestsWithBothSplit, gradleKotlinManifestFoundInManifestsWithBothSplitAndFlavor,
+				gradleKotlinManifestFoundInMergedManifests, gradleKotlinManifestFoundInMergedManifestsWithAbiSplit, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavor,
+				gradleKotlinManifestFoundInMergedManifestsWithDensitySplit, gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavor,
+				gradleKotlinManifestFoundInMergedManifestsWithBothSplit, gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavor, gradleKotlinManifestFoundInMergedManifestsV33,
+				gradleKotlinManifestFoundInMergedManifestsWithAbiSplitV33, gradleKotlinManifestFoundInMergedManifestsWithAbiSplitAndFlavorV33,
+				gradleKotlinManifestFoundInMergedManifestsWithDensitySplitV33, gradleKotlinManifestFoundInMergedManifestsWithDensitySplitAndFlavorV33,
+				gradleKotlinManifestFoundInMergedManifestsWithBothSplitV33, gradleKotlinManifestFoundInMergedManifestsWithBothSplitAndFlavorV33, mavenManifestFoundInTarget, mavenManifestFoundInSrc,
+				mavenManifestFoundInRoot, eclipseManifestFound, gradleManifestNotFound, gradleKotlinManifestNotFound, mavenManifestNotFound, eclipseManifestNotFound, noGeneratedFolderFound);
 	}
 
 	@Test


### PR DESCRIPTION
Google updated the generated code folder for Java Builds and with this PR we support those new folders for Manifest detection. :)

Fixes https://github.com/androidannotations/androidannotations/issues/2229.